### PR TITLE
cannot built the master branch with gc-7.1

### DIFF
--- a/main.c
+++ b/main.c
@@ -419,7 +419,11 @@ main(int argc, char **argv, char **envp)
     char **getimage_args = NULL;
 #endif /* defined(DONT_CALL_GC_AFTER_FORK) && defined(USE_IMAGE) */
     GC_INIT();
+#if (GC_VERSION_MAJOR>=7) && (GC_VERSION_MINOR>=2)
     GC_set_oom_fn(die_oom);
+#else
+    GC_oom_fn = die_oom;
+#endif
 #if defined(ENABLE_NLS) || (defined(USE_M17N) && defined(HAVE_LANGINFO_CODESET))
     setlocale(LC_ALL, "");
 #endif


### PR DESCRIPTION
The master branch cannot be built with gc-7.1
```
gcc  -I. -I. -g -O2 -I./libwc    -DHAVE_CONFIG_H -DAUXBIN_DIR=\"/usr/local/libexec/w3m\" -DCGIBIN_DIR=\"/usr/local/libexec/w3m/cgi-bin\" -DHELP_DIR=\"/usr/local/share/w3m\" -DETC_DIR=\"/usr/local/etc\" -DCONF_DIR=\"/usr/local/etc/w3m\" -DRC_DIR=\"~/.w3m\" -DLOCALEDIR=\"/usr/local/share/locale\" -o w3m main.o file.o buffer.o display.o etc.o search.o linein.o table.o local.o form.o map.o frame.o rc.o menu.o mailcap.o image.o symbol.o entity.o terms.o url.o ftp.o mimehead.o regex.o news.o func.o cookie.o history.o backend.o keybind.o anchor.o parsetagx.o tagtable.o istream.o version.o  -lm  -lbsd -lnsl -ldl -L. -lindep  -lgc -L./libwc -lwc -lssl -lcrypto   -lssl -lcrypto -lgpm -ltermcap
main.o: In function `main':
/home/yshl/w3m-debian/main.c:422: undefined reference to `GC_set_oom_fn'
collect2: ld returned 1 exit status
make: *** [w3m] Error 1
```
gc-7.1 does not have GC_set_oom_fn.
