### PR TITLE
Error of certdata2pem.rb in doc-jp/README.SSL 

### DIFF
--- a/doc-jp/README.SSL
+++ b/doc-jp/README.SSL
@@ -85,6 +85,9 @@ SSL サポートについて
 #
 # certdata2pem.rb
 
+if RUBY_VERSION>="1.9"
+  Encoding.default_external="UTF-8"
+end
 while line = $stdin.gets
   next if line =~ /^#/
   next if line =~ /^\s*$/


### PR DESCRIPTION
When I make *.pem files by certdata2pem.rb in doc-jp/README.SSL, but an error occurs.
```
% ruby certdata2pem.rb < certdata.txt
Created Equifax_Secure_CA.pe
.....
Created VeriSign_Class_3_Public_Primary_Certification_Authority_-_G4.pem
certdata2pem.rb:12:in `<main>': invalid byte sequence in EUC-JP (ArgumentError)
```
The certdata.txt has UTF-8 characters, but my ruby's default external encoding is EUC-JP.
