### PR TITLE
Fix table rowspan and colspan

### DIFF
--- a/table.c
+++ b/table.c
@@ -2599,12 +2599,16 @@ feed_table_tag(struct table *tbl, char *line, struct table_mode *mode,
 	    if ((tbl->row + rowspan) >= tbl->max_rowsize)
 		check_row(tbl, tbl->row + rowspan);
 	}
+	if (rowspan < 1)
+	    rowspan = 1;
 	if (parsedtag_get_value(tag, ATTR_COLSPAN, &colspan)) {
 	    if ((tbl->col + colspan) >= MAXCOL) {
 		/* Can't expand column */
 		colspan = MAXCOL - tbl->col;
 	    }
 	}
+	if (colspan < 1)
+	    colspan = 1;
 	if (parsedtag_get_value(tag, ATTR_ALIGN, &i)) {
 	    switch (i) {
 	    case ALIGN_LEFT:


### PR DESCRIPTION
rowspan and colspan should be at least 1. If either one of them is zero and the
other is larger than 1, HTT_X and HTT_Y attributes are not set correctly. Then
the calculation of maxcol or maxrow are wrong (not including colspan/rowspan).
w3m will overflow buffers later.

Examples to trigger this issue:
```
   echo '<table>0<td rowspan=0 colspan=300>a' | ./w3m -T text/html -dump
   echo '<table>0<td rowspan=0 colspan=30><img width=900000 src=0 height=0>'  | ./w3m -T text/html -dump
```