### PR TITLE
Fix potential heap buffer corruption due to Strgrow

### DIFF
--- a/Str.c
+++ b/Str.c
@@ -232,8 +232,8 @@ Strgrow(Str x)
 {
     char *old = x->ptr;
     int newlen;
-    newlen = x->length * 6 / 5;
-    if (newlen == x->length)
+    newlen = x->area_size * 6 / 5;
+    if (newlen == x->area_size)
 	newlen += 2;
     x->ptr = GC_MALLOC_ATOMIC(newlen);
     x->area_size = newlen;


### PR DESCRIPTION
If Str.length = 5 and area_size = 6, the result of Strgrow is still
area_size = 6. For such case, Strcat_char and Strinsert_char will
overflow one byte.