### PR TITLE
Fix suspend (^Z) behavior.

### DIFF
--- a/main.c
+++ b/main.c
@@ -2619,7 +2619,17 @@ DEFUN(susp, INTERRUPT SUSPEND, "Suspend w3m to background")
 	shell = "/bin/sh";
     system(shell);
 #else				/* SIGSTOP */
+#ifdef SIGTSTP
+    signal(SIGTSTP, SIG_DFL);  /* just in case */
+    /*
+     * Note: If susp() was called from SIGTSTP handler,
+     * unblocking SIGTSTP would be required here.
+     * Currently not.
+     */
+    kill(0, SIGTSTP);  /* stop whole job, not a single process */
+#else
     kill((pid_t) 0, SIGSTOP);
+#endif
 #endif				/* SIGSTOP */
     fmInit();
     displayBuffer(Currentbuf, B_FORCE_REDRAW);


### PR DESCRIPTION
Suspend the job w3m belongs to, not w3m only.

Signed-off-by: Thomas Klausner <wiz@NetBSD.org>

(This patch has been in pkgsrc since the year 2000.)