### PR TITLE
correct <base ...> parsing and do not turn a form's GET into POST

### DIFF
--- a/file.c
+++ b/file.c
@@ -5993,7 +5993,7 @@ HTMLlineproc2body(Buffer *buf, Str (*feed) (), int llimit)
 				       buf->document_charset);
 			if (!buf->baseURL)
 			    buf->baseURL = New(ParsedURL);
-			parseURL(p, buf->baseURL, NULL);
+			parseURL2(p, buf->baseURL, &buf->currentURL);
 #if defined(USE_M17N) || defined(USE_IMAGE)
 			base = buf->baseURL;
 #endif

--- a/form.c
+++ b/form.c
@@ -56,10 +56,9 @@ newFormList(char *action, char *method, char *charset, char *enctype,
 	m = FORM_METHOD_INTERNAL;
     /* unknown method is regarded as 'get' */
 
-    if (enctype != NULL && !strcasecmp(enctype, "multipart/form-data")) {
+    if (m != FORM_METHOD_GET && enctype != NULL &&
+	!strcasecmp(enctype, "multipart/form-data")) {
 	e = FORM_ENCTYPE_MULTIPART;
-	if (m == FORM_METHOD_GET)
-	    m = FORM_METHOD_POST;
     }
 
 #ifdef USE_M17N


### PR DESCRIPTION
The commit comments have detailed information.

Non-absolute-URI <base href="..."> values were not being handled properly.
A &lt;form method="GET"> was incorrectly being turned into a "POST" in some cases.