### PR TITLE
Fix crashes when some external APIs fail

### DIFF
--- a/file.c
+++ b/file.c
@@ -611,8 +611,10 @@ readHeader(URLFile *uf, Buffer *newBuf, int thru, ParsedURL *pu)
 	if(w3m_reqlog){
 	    FILE *ff;
 	    ff = fopen(w3m_reqlog, "a");
-	    Strfputs(tmp, ff);
-	    fclose(ff);
+            if(ff){
+	        Strfputs(tmp, ff);
+	        fclose(ff);
+            }
 	}
 	if (src)
 	    Strfputs(tmp, src);
@@ -7580,6 +7582,8 @@ loadImageBuffer(URLFile *uf, Buffer *newBuf)
     tmp = Sprintf("<img src=\"%s\"><br><br>", html_quote(image.url));
     tmpf = tmpfname(TMPF_SRC, ".html");
     src = fopen(tmpf->ptr, "w");
+    if (src == NULL)
+        return NULL;
     newBuf->mailcap_source = tmpf->ptr;
 
     init_stream(&f, SCM_LOCAL, newStrStream(tmp));

--- a/local.c
+++ b/local.c
@@ -426,7 +426,10 @@ localcgi_post(char *uri, char *qstr, FormList *request, char *referer)
     }
 
 #ifdef HAVE_CHDIR		/* ifndef __EMX__ ? */
-    chdir(cgi_dir);
+    if (chdir(cgi_dir) == -1) {
+        fprintf(stderr, "failed to chdir to %s: %s\n", cgi_dir, strerror(errno));
+        exit(1);
+    }
 #endif
     execl(file, cgi_basename, NULL);
     fprintf(stderr, "execl(\"%s\", \"%s\", NULL): %s\n",

--- a/url.c
+++ b/url.c
@@ -1752,6 +1752,8 @@ openURL(char *url, ParsedURL *pu, ParsedURL *current,
 		write(sock, tmp->ptr, tmp->length);
 	    if(w3m_reqlog){
 		FILE *ff = fopen(w3m_reqlog, "a");
+		if (ff == NULL)
+		    return uf;
 		if (sslh)
 		    fputs("HTTPS: request via SSL\n", ff);
 		else
@@ -1774,6 +1776,8 @@ openURL(char *url, ParsedURL *pu, ParsedURL *current,
 	    write(sock, tmp->ptr, tmp->length);
 	    if(w3m_reqlog){
 		FILE *ff = fopen(w3m_reqlog, "a");
+		if (ff == NULL)
+		    return uf;
 		fwrite(tmp->ptr, sizeof(char), tmp->length, ff);
 		fclose(ff);
 	    }


### PR DESCRIPTION
Hi,

I'm a PhD student. I analyzed the w3m source code and found some potential API bugs that may cause crashes.

These crashes are mainly caused by insufficient error handling of API functions like fopen or chdir.

I think it's unsafe to assume the library function would be correct. It would be better if we could handle the error properly.

Best, 
Zhouyang