### PR TITLE
Do not use deprecated features with openssl-1.1

### DIFF
--- a/istream.c
+++ b/istream.c
@@ -421,7 +421,11 @@ ssl_check_cert_ident(X509 * x, char *hostname)
 	    for (i = 0; i < n; i++) {
 		gn = sk_GENERAL_NAME_value(alt, i);
 		if (gn->type == GEN_DNS) {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 		    char *sn = ASN1_STRING_data(gn->d.ia5);
+#else
+        char *sn = ASN1_STRING_get0_data(gn->d.ia5);
+#endif
 		    int sl = ASN1_STRING_length(gn->d.ia5);
 
 		    if (!seen_dnsname)

--- a/url.c
+++ b/url.c
@@ -319,12 +319,16 @@ openSSLHandle(int sock, char *hostname, char **p_cert)
 #endif				/* defined(USE_SSL_VERIFY) */
     if (ssl_ctx == NULL) {
 	int option;
-#if SSLEAY_VERSION_NUMBER < 0x0800
+#if OPENSSL_VERSION_NUMBER < 0x0800
 	ssl_ctx = SSL_CTX_new();
 	X509_set_default_verify_paths(ssl_ctx->cert);
 #else				/* SSLEAY_VERSION_NUMBER >= 0x0800 */
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 	SSLeay_add_ssl_algorithms();
 	SSL_load_error_strings();
+#else
+  OPENSSL_init_ssl(0, NULL);
+#endif
 	if (!(ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
 	    goto eend;
 	SSL_CTX_set_cipher_list(ssl_ctx, "DEFAULT:!LOW:!RC4:!EXP");


### PR DESCRIPTION
See downstream bug report: https://bugs.gentoo.org/592510