### PR TITLE
Allow to override UserAgent

### DIFF
--- a/fm.h
+++ b/fm.h
@@ -935,6 +935,7 @@ global int w3m_dump init(0);
 global int w3m_halfload init(FALSE);
 global Str header_string init(NULL);
 global int override_content_type init(FALSE);
+global int override_user_agent init(FALSE);
 
 #ifdef USE_COLOR
 global int useColor init(TRUE);

--- a/main.c
+++ b/main.c
@@ -375,6 +375,8 @@ make_optional_header_string(char *s)
     Strcopy_charp_n(hs, s, p - s);
     if (!Strcasecmp_charp(hs, "content-type"))
 	override_content_type = TRUE;
+    if (!Strcasecmp_charp(hs, "user-agent"))
+	override_user_agent = TRUE;
     Strcat_charp(hs, ": ");
     if (*(++p)) {		/* not null header */
 	SKIP_BLANKS(p);		/* skip white spaces */

--- a/url.c
+++ b/url.c
@@ -1324,12 +1324,14 @@ otherinfo(ParsedURL *target, ParsedURL *current, char *referer)
     const int *no_referer_ptr;
     int no_referer;
 
-    Strcat_charp(s, "User-Agent: ");
-    if (UserAgent == NULL || *UserAgent == '\0')
-	Strcat_charp(s, w3m_version);
-    else
-	Strcat_charp(s, UserAgent);
-    Strcat_charp(s, "\r\n");
+    if (!override_user_agent) {
+        Strcat_charp(s, "User-Agent: ");
+        if (UserAgent == NULL || *UserAgent == '\0')
+            Strcat_charp(s, w3m_version);
+        else
+            Strcat_charp(s, UserAgent);
+        Strcat_charp(s, "\r\n");
+    }
 
     Strcat_m_charp(s, "Accept: ", AcceptMedia, "\r\n", NULL);
     Strcat_m_charp(s, "Accept-Encoding: ", AcceptEncoding, "\r\n", NULL);


### PR DESCRIPTION
Hello,

Adding on command line the user agent add a duplicate header:

```
./w3m -header "User-Agent: Mozilla" http://localhost:9999

GET / HTTP/1.0
User-Agent: w3m/0.5.3+git20190105
Accept: text/html, text/*;q=0.5, image/*, application/*, message/*, x-scheme-handler/*, audio/*, video/*, inode/*
Accept-Encoding: gzip, compress, bzip, bzip2, deflate
Accept-Language: en;q=1.0
Host: localhost:9999
User-Agent: Mozilla
```

As a result most server will take the first given; the default
w3m_version or the one defined on config `user_agent`

With this patch we can now override `User-Agent` from command line

Cheers,
Laurent