### PR TITLE
Add command to go home.

### DIFF
--- a/keybind.c
+++ b/keybind.c
@@ -13,7 +13,7 @@ unsigned char GlobalKeymap[128] = {
     /*  C-p     C-q     C-r     C-s     C-t     C-u     C-v     C-w      */
     movU, closeT, isrchbak, isrchfor, tabA, prevA, pgFore, wrapToggle,
     /*  C-x     C-y     C-z     C-[     C-\     C-]     C-^     C-_      */
-    nulcmd, nulcmd, susp, escmap, nulcmd, nulcmd, nulcmd, nulcmd,
+    nulcmd, nulcmd, susp, escmap, nulcmd, nulcmd, nulcmd, goHome,
     /*  SPC     !       "       #       $       %       &       '        */
     pgFore, execsh, reMark, pipesh, linend, nulcmd, nulcmd, nulcmd,
     /*  (       )       *       +       ,       -       .       /        */

--- a/main.c
+++ b/main.c
@@ -4256,6 +4256,23 @@ DEFUN(goURL, GOTO, "Open specified document in a new buffer")
     goURL0("Goto URL: ", FALSE);
 }
 
+DEFUN(goHome, GOTO_HOME, "Open home page in a new buffer")
+{
+    char *url;
+    if ((url = getenv("HTTP_HOME")) != NULL ||
+        (url = getenv("WWW_HOME")) != NULL) {
+        ParsedURL p_url;
+        Buffer *cur_buf = Currentbuf;
+        SKIP_BLANKS(url);
+        url = url_encode(url, NULL, 0);
+        parseURL2(url, &p_url, NULL);
+        pushHashHist(URLHist, parsedURL2Str(&p_url)->ptr);
+        cmd_loadURL(url, NULL, NULL, NULL);
+        if (Currentbuf != cur_buf)	/* success */
+        pushHashHist(URLHist, parsedURL2Str(&Currentbuf->currentURL)->ptr);
+    }
+}
+
 DEFUN(gorURL, GOTO_RELATIVE, "Go to relative address")
 {
     goURL0("Goto relative URL: ", TRUE);

--- a/proto.h
+++ b/proto.h
@@ -81,6 +81,7 @@ extern void prevBf(void);
 extern void backBf(void);
 extern void deletePrevBuf(void);
 extern void goURL(void);
+extern void goHome(void);
 extern void gorURL(void);
 extern void ldBmark(void);
 extern void adBmark(void);


### PR DESCRIPTION
When w3m is launched, if no other options are specified, it attempts to read `HTTP_HOME` and `WWW_HOME` from the environment and upon finding a value for one of these to load the url specified.  Once launched, though, w3m provides no convenience for navigating to the home page.

Here, that ability is added.  A new command `GOTO_HOME` is defined with a default key binding of `C-_`.