### PR TITLE
Rudimentary support for figure, figcaption

### DIFF
--- a/file.c
+++ b/file.c
@@ -4492,6 +4492,8 @@ HTMLtagproc1(struct parsed_tag *tag, struct html_feed_environ *h_env)
     case HTML_N_Q:
 	HTMLlineproc1("'", h_env);
 	return 1;
+    case HTML_FIGURE:
+    case HTML_N_FIGURE:
     case HTML_P:
     case HTML_N_P:
 	CLOSE_A;
@@ -4506,6 +4508,8 @@ HTMLtagproc1(struct parsed_tag *tag, struct html_feed_environ *h_env)
 	    obuf->flag |= RB_P;
 	}
 	return 1;
+    case HTML_FIGCAPTION:
+    case HTML_N_FIGCAPTION:
     case HTML_BR:
 	flushline(h_env, obuf, envs[h_env->envc].indent, 1, h_env->limit);
 	h_env->blank_lines = 0;

--- a/html.c
+++ b/html.c
@@ -268,10 +268,11 @@ TagInfo TagMAP[MAX_HTMLTAG] = {
     {"small", ALST_NOP, MAXA_NOP, 0}, 		/* 139 HTML_SMALL */
     {"/small", NULL, 0, TFLG_END},	/* 140 HTML_N_SMALL */
 
-    {NULL, NULL, 0, 0},		/* 141 Undefined */
-    {NULL, NULL, 0, 0},		/* 142 Undefined */
-    {NULL, NULL, 0, 0},		/* 143 Undefined */
-    {NULL, NULL, 0, 0},		/* 144 Undefined */
+    {"figure", ALST_P, MAXA_P, 0},		/* 141 HTML_FIGURE */
+    {"/figure", NULL, 0, 0},			/* 142 HTML_N_FIGURE */
+    {"figcaption", ALST_P, MAXA_P, 0},		/* 143 HTML_FIGCAPTION */
+    {"/figcaption", NULL, 0, TFLG_END},		/* 144 HTML_N_FIGCAPTION */
+
     {NULL, NULL, 0, 0},		/* 145 Undefined */
     {NULL, NULL, 0, 0},		/* 146 Undefined */
     {NULL, NULL, 0, 0},		/* 147 Undefined */

--- a/html.h
+++ b/html.h
@@ -231,6 +231,10 @@ typedef struct {
 #define HTML_PARAM      138
 #define HTML_SMALL      139
 #define HTML_N_SMALL    140
+#define HTML_FIGURE     141
+#define HTML_N_FIGURE   142
+#define HTML_FIGCAPTION 143
+#define HTML_N_FIGCAPTION   144
 
    /* pseudo tag */
 #define HTML_SELECT_INT     160

--- a/tagtable.tab
+++ b/tagtable.tab
@@ -192,6 +192,10 @@ optgroup	HTML_OPTGROUP
 param		HTML_PARAM
 small		HTML_SMALL
 /small		HTML_N_SMALL
+figure		HTML_FIGURE
+/figure		HTML_N_FIGURE
+figcaption	HTML_FIGCAPTION
+/figcaption	HTML_N_FIGCAPTION
 internal	HTML_INTERNAL
 /internal	HTML_N_INTERNAL
 select_int	HTML_SELECT_INT


### PR DESCRIPTION
Rudimentary support for figure and figcaption (treated like p and br) so these tags don’t just get treated like spans.