### PR TITLE
Allow spaces to be entered in URL fields

### DIFF
--- a/fm.h
+++ b/fm.h
@@ -961,6 +961,7 @@ global int confirm_on_quit init(TRUE);
 global int use_mark init(FALSE);
 #endif
 global int emacs_like_lineedit init(FALSE);
+global int space_autocomplete init(FALSE);
 global int vi_prec_num init(FALSE);
 global int label_topline init(FALSE);
 global int nextpage_topline init(FALSE);

--- a/linein.c
+++ b/linein.c
@@ -184,7 +184,7 @@ inputLineHistSearch(char *prompt, char *def_str, int flag, Hist *hist,
 	cm_clear = TRUE;
 	cm_disp_clear = TRUE;
 	if (!i_quote &&
-	    (((cm_mode & CPL_ALWAYS) && (c == CTRL_I || c == ' ')) ||
+	    (((cm_mode & CPL_ALWAYS) && (c == CTRL_I || (space_autocomplete && c == ' ')) ||
 	     ((cm_mode & CPL_ON) && (c == CTRL_I)))) {
 	    if (emacs_like_lineedit && cm_next) {
 		_dcompl();

--- a/rc.c
+++ b/rc.c
@@ -131,6 +131,7 @@ static int OptionEncode = FALSE;
 #define CMT_USE_MARK	N_("Enable mark operations")
 #endif
 #define CMT_EMACS_LIKE_LINEEDIT	N_("Enable Emacs-style line editing")
+#define CMT_SPACE_AUTOCOMPLETE  N_("Space key triggers file completion while editing URLs")
 #define CMT_VI_PREC_NUM	 N_("Enable vi-like numeric prefix")
 #define CMT_LABEL_TOPLINE N_("Move cursor to top line when going to label")
 #define CMT_NEXTPAGE_TOPLINE N_("Move cursor to top line when moving to next page")
@@ -485,6 +486,8 @@ struct param_ptr params3[] = {
 #endif
     {"emacs_like_lineedit", P_INT, PI_ONOFF, (void *)&emacs_like_lineedit,
      CMT_EMACS_LIKE_LINEEDIT, NULL},
+    {"space_autocomplete", P_INT, PI_ONOFF, (void *)&space_autocomplete,
+     CMT_SPACE_AUTOCOMPLETE, NULL},
     {"vi_prec_num", P_INT, PI_ONOFF, (void *)&vi_prec_num, CMT_VI_PREC_NUM,
      NULL},
     {"mark_all_pages", P_INT, PI_ONOFF, (void *)&MarkAllPages,


### PR DESCRIPTION
For some reason the space key previously triggered filename completion when typed into the location field (command GOTO), so the only way of using spaces in URLs I found was to type %20 instead. Which is still highly inconvenient when using urimethodmap with a search engine, for example.

With this patch the space key actually does what one would expect it to do (insert spaces), and the old behavior can still be enabled in the options menu.