### PR TITLE
Support brotli content encoding

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -241,11 +241,13 @@ typedef RETSIGTYPE MySignalHandler;
 #define DEV_TTY_PATH	"/dev/tty"
 #define CGI_EXTENSION	".cgi"
 #endif
+#define BROTLI_CMDNAME "brotli"
 
 #define PATH_SEPARATOR	':'
 #define GUNZIP_NAME  "gunzip"
 #define BUNZIP2_NAME "bunzip2"
 #define INFLATE_NAME "inflate"
+#define BROTLI_NAME "brotli"
 
 #ifdef __MINGW32_VERSION
 #define SIGKILL SIGTERM

--- a/html.h
+++ b/html.h
@@ -84,6 +84,7 @@ typedef struct {
 #define CMP_GZIP         2
 #define CMP_BZIP2        3
 #define CMP_DEFLATE      4
+#define CMP_BROTLI       5
 
 #define ENC_7BIT	0
 #define ENC_BASE64	1


### PR DESCRIPTION
Add support for the brotli compression algorithm using the `brotli -d` command. (`unbrotli` doesn't seem to be universally supported for some reason).