### PR TITLE
Improve description list rendering

### DIFF
--- a/html.c
+++ b/html.c
@@ -274,8 +274,9 @@ TagInfo TagMAP[MAX_HTMLTAG] = {
     {"/figcaption", NULL, 0, TFLG_END},		/* 144 HTML_N_FIGCAPTION */
     {"section", ALST_NOP, MAXA_NOP, 0},		/* 145 HTML_SECTION */
     {"/section", NULL, 0, TFLG_END},		/* 146 HTML_N_SECTION */
+    {"/dt", NULL, 0, TFLG_END},		/* 147 HTML_N_DT */
+    {"/dd", NULL, 0, TFLG_END},		/* 147 HTML_N_DD */
 
-    {NULL, NULL, 0, 0},		/* 147 Undefined */
     {NULL, NULL, 0, 0},		/* 148 Undefined */
     {NULL, NULL, 0, 0},		/* 149 Undefined */
     {NULL, NULL, 0, 0},		/* 150 Undefined */

--- a/html.h
+++ b/html.h
@@ -238,6 +238,8 @@ typedef struct {
 #define HTML_N_FIGCAPTION   144
 #define HTML_SECTION    145
 #define HTML_N_SECTION  146
+#define HTML_N_DT       147
+#define HTML_N_DD       148
 
    /* pseudo tag */
 #define HTML_SELECT_INT     160

--- a/tagtable.tab
+++ b/tagtable.tab
@@ -203,6 +203,8 @@ select_int	HTML_SELECT_INT
 option_int	HTML_OPTION_INT
 section		HTML_SECTION
 /section	HTML_N_SECTION
+/dt		HTML_N_DT
+/dd		HTML_N_DD
 textarea_int	HTML_TEXTAREA_INT
 /textarea_int	HTML_N_TEXTAREA_INT
 pre_plain	HTML_PRE_PLAIN

--- a/tests/dl.expected
+++ b/tests/dl.expected
@@ -28,6 +28,8 @@ FF
     graphical web browser developed by the
     Mozilla Corporation and hundreds of
     volunteers.
+    nested
+        com item
     The Red Panda also known as the Lesser
     Panda, Wah, Bear Cat or Firefox, is a
     mostly herbivorous mammal, slightly larger

--- a/tests/dl.expected
+++ b/tests/dl.expected
@@ -1,0 +1,18 @@
+w3m
+WWW wo miru
+    A pager with web browsing capabilities,
+    maintained for Debian.
+
+Firefox
+(linebreak)
+
+FF
+.
+    A free, open source, cross-platform,
+    graphical web browser developed by the
+    Mozilla Corporation and hundreds of
+    volunteers.
+    The Red Panda also known as the Lesser
+    Panda, Wah, Bear Cat or Firefox, is a
+    mostly herbivorous mammal, slightly larger
+    than a domestic cat (60 cm long).

--- a/tests/dl.expected
+++ b/tests/dl.expected
@@ -5,9 +5,25 @@ WWW wo miru
 
 Firefox
 (linebreak)
+FF  A free, open source, cross-platform,
+    graphical web browser developed by the
+    Mozilla Corporation and hundreds of
+    volunteers.
+    The Red Panda also known as the Lesser
+    Panda, Wah, Bear Cat or Firefox, is a
+    mostly herbivorous mammal, slightly larger
+    than a domestic cat (60 cm long).
+
+Non-compact dl
+w3m
+WWW wo miru
+    A pager with web browsing capabilities,
+    maintained for Debian.
+
+Firefox
+(linebreak)
 
 FF
-.
     A free, open source, cross-platform,
     graphical web browser developed by the
     Mozilla Corporation and hundreds of
@@ -16,3 +32,4 @@ FF
     Panda, Wah, Bear Cat or Firefox, is a
     mostly herbivorous mammal, slightly larger
     than a domestic cat (60 cm long).
+

--- a/tests/dl.html
+++ b/tests/dl.html
@@ -1,4 +1,4 @@
-<dl>
+<dl compact>
   <dt>w3m</dt>
   <dt>WWW wo miru</dt>
   <dd>
@@ -7,7 +7,29 @@
   </dd>
   <dt><br>Firefox<br>(linebreak)</dt><br>
   <dt>FF</dt>
-  .
+  <dd>
+    A free, open source, cross-platform,<br>
+    graphical web browser developed by the<br>
+    Mozilla Corporation and hundreds of<br>
+    volunteers.
+  </dd>
+  <dd>
+    The Red Panda also known as the Lesser<br>
+    Panda, Wah, Bear Cat or Firefox, is a<br>
+    mostly herbivorous mammal, slightly larger<br>
+    than a domestic cat (60 cm long).
+  </dd>
+</dl>
+<dl>
+  Non-compact dl
+  <dt>w3m</dt>
+  <dt>WWW wo miru</dt>
+  <dd>
+    A pager with web browsing capabilities,<br>
+    maintained for Debian.
+  </dd>
+  <dt><br>Firefox<br>(linebreak)</dt><br>
+  <dt>FF</dt>
   <dd>
     A free, open source, cross-platform,<br>
     graphical web browser developed by the<br>

--- a/tests/dl.html
+++ b/tests/dl.html
@@ -1,0 +1,23 @@
+<dl>
+  <dt>w3m</dt>
+  <dt>WWW wo miru</dt>
+  <dd>
+    A pager with web browsing capabilities,<br>
+    maintained for Debian.
+  </dd>
+  <dt><br>Firefox<br>(linebreak)</dt><br>
+  <dt>FF</dt>
+  .
+  <dd>
+    A free, open source, cross-platform,<br>
+    graphical web browser developed by the<br>
+    Mozilla Corporation and hundreds of<br>
+    volunteers.
+  </dd>
+  <dd>
+    The Red Panda also known as the Lesser<br>
+    Panda, Wah, Bear Cat or Firefox, is a<br>
+    mostly herbivorous mammal, slightly larger<br>
+    than a domestic cat (60 cm long).
+  </dd>
+</dl>

--- a/tests/dl.html
+++ b/tests/dl.html
@@ -35,6 +35,17 @@
     graphical web browser developed by the<br>
     Mozilla Corporation and hundreds of<br>
     volunteers.
+    <dl>
+      <dt>nested</dt>
+      <dd>
+        <dl compact>
+          <dt>com</dt>
+          <dd>
+            item
+          </dd>
+        </dl>
+      </dd>
+    </dl>
   </dd>
   <dd>
     The Red Panda also known as the Lesser<br>


### PR DESCRIPTION
&lt;DL&gt; no longer indents description term names. Rendering with this patch is mostly identical to that of Firefox, except w3m also supports &lt;dl compact&gt; which is no longer supported in HTML5 (CSS is recommended instead so w3m doesn't disable compact mode support in HTML5 mode either).

Fixes #162 