### PR TITLE
Improved iTerm2 image display + initial kitty image support

### DIFF
--- a/etc.c
+++ b/etc.c
@@ -2013,7 +2013,7 @@ base64_encode(const unsigned char *src, size_t len)
 {
     unsigned char *w, *at;
     const unsigned char *in, *endw;
-    int j;
+    unsigned long j;
     size_t k;
 
     k = len;
@@ -2024,7 +2024,9 @@ base64_encode(const unsigned char *src, size_t len)
     if (k + 1 < len)
 	return NULL;
 
-    w = GC_MALLOC_ATOMIC_IGNORE_OFF_PAGE(k + 1);
+    w = GC_MALLOC_ATOMIC(k + 1);
+    if (!w)
+	return NULL;
     w[k] = 0;
 
     at = w;

--- a/etc.c
+++ b/etc.c
@@ -2016,6 +2016,10 @@ base64_encode(const unsigned char *src, size_t len)
     unsigned long j;
     size_t k;
 
+
+    if (!len)
+	return NULL;
+
     k = len;
     if (k % 3)
       k += 3 - (k % 3);

--- a/fm.h
+++ b/fm.h
@@ -316,6 +316,7 @@ extern int REV_LB[];
 #define INLINE_IMG_OSC5379	1
 #define INLINE_IMG_SIXEL	2
 #define INLINE_IMG_ITERM2	3
+#define INLINE_IMG_KITTY	4
 
 /* 
  * Types.

--- a/image.c
+++ b/image.c
@@ -259,7 +259,7 @@ drawImage()
 	    } else if (enable_inline_image == INLINE_IMG_ITERM2) {
 		put_image_iterm2(url, x, y, sw, sh);
 	    } else if (enable_inline_image == INLINE_IMG_KITTY) {
-		put_image_kitty(url, x, y, w, h, i->sx, i->sy, sw * pixel_per_char, sh * pixel_per_line_i, sw, sh);
+		put_image_kitty(url, x, y, i->width, i->height, i->sx, i->sy, sw * pixel_per_char, sh * pixel_per_line_i, sw, sh);
 	    }
 
 	    continue ;

--- a/image.c
+++ b/image.c
@@ -198,6 +198,8 @@ syncImage(void)
 void put_image_osc5379(char *url, int x, int y, int w, int h, int sx, int sy, int sw, int sh);
 void put_image_sixel(char *url, int x, int y, int w, int h, int sx, int sy, int sw, int sh, int n_terminal_image);
 void put_image_iterm2(char *url, int x, int y, int w, int h);
+void put_image_kitty(char *url, int x, int y, int w, int h, int sx, int sy, int
+    sw, int sh, int c, int r);
 
 void
 drawImage()
@@ -256,6 +258,8 @@ drawImage()
 		put_image_osc5379(url, x, y, w, h, sx, sy, sw, sh);
 	    } else if (enable_inline_image == INLINE_IMG_ITERM2) {
 		put_image_iterm2(url, x, y, sw, sh);
+	    } else if (enable_inline_image == INLINE_IMG_KITTY) {
+		put_image_kitty(url, x, y, w, h, i->sx, i->sy, sw * pixel_per_char, sh * pixel_per_line_i, sw, sh);
 	    }
 
 	    continue ;

--- a/rc.c
+++ b/rc.c
@@ -374,7 +374,7 @@ static struct sel_c inlineimgstr[] = {
     {N_S(INLINE_IMG_OSC5379), N_("OSC 5379 (mlterm)")},
     {N_S(INLINE_IMG_SIXEL), N_("sixel (img2sixel)")},
     {N_S(INLINE_IMG_ITERM2), N_("OSC 1337 (iTerm2)")},
-    {N_S(INLINE_IMG_KITTY), N_("kitty (PNG only)")},
+    {N_S(INLINE_IMG_KITTY), N_("kitty (ImageMagick)")},
     {0, NULL, NULL}
 };
 #endif				/* USE_IMAGE */

--- a/rc.c
+++ b/rc.c
@@ -374,6 +374,7 @@ static struct sel_c inlineimgstr[] = {
     {N_S(INLINE_IMG_OSC5379), N_("OSC 5379 (mlterm)")},
     {N_S(INLINE_IMG_SIXEL), N_("sixel (img2sixel)")},
     {N_S(INLINE_IMG_ITERM2), N_("OSC 1337 (iTerm2)")},
+    {N_S(INLINE_IMG_KITTY), N_("kitty (PNG only)")},
     {0, NULL, NULL}
 };
 #endif				/* USE_IMAGE */

--- a/terms.c
+++ b/terms.c
@@ -564,7 +564,7 @@ put_image_kitty(char *url, int x, int y, int w, int h, int sx, int sy, int sw,
 	return;
 
     type = guessContentType(url);
-    if(!strcasecmp(type, "image/png")) {
+    if(type && !strcasecmp(type, "image/png")) {
       t = 100;
     } else {
       /* TODO: kitty +kitten icat or link imlib/gdkpixbuf? */


### PR DESCRIPTION
I've changed put_image_iterm2 so that it encodes base64 data in chunks of 4KB instead of unnecessarily allocating megabytes of memory.

I've also added support for the kitty image protocol. Well, at least the part where it accepts PNG files, for now all other types of image are just ignored. I'd like to add support for those, but for that we'll first need to convert images to RGBA. I've thought of two approaches:

1. Convert everything to PNG with imagemagick's `convert` command. Straightforward, though not the cleanest solution. Then again, the sixel option also uses an external command.
2. Integrate kitty support into w3mimgdisplay (and use imlib/gdkpixbuf for RGBA). No idea how feasible this would be, by including terms.c/terms.h I'd imagine it could work.

Let me know which one you'd accept, or if you have alternative ideas.