### PR TITLE
Added initial fuzzer for integration with OSS-Fuzz.

### DIFF
--- a/fuzz/fuzz-conv.c
+++ b/fuzz/fuzz-conv.c
@@ -1,0 +1,51 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include "wc.h"
+
+char *get_null_terminated(const uint8_t *data, size_t size) {
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL){
+            return NULL;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+    return new_str;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+    if (size < 30) {
+        return 0;
+    }
+
+    char *new_str1 = get_null_terminated(data, 20);
+    data += 20; size -= 20;
+    char *new_str2 = get_null_terminated(data, size);
+
+    wc_ces old, from, to;
+    from = wc_guess_charset_short(new_str1,0);
+    to = wc_guess_charset_short(new_str2, 0);
+
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+            return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    FILE *f = fopen(filename, "r");
+    Str s = Strfgetall(f);
+    wc_Str_conv_with_detect(s, &from, from, to);
+    if (s != NULL) {
+            Strfree(s);
+    }
+
+    unlink(filename);
+
+    free(new_str1);
+    free(new_str2);
+    return 0;
+}


### PR DESCRIPTION
Hi Maintainers,

I have worked a bit on setting fuzzing up for w3m by way of OSS-Fuzz. Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects, and it would be great to have w3m integrated. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

In this PR google/oss-fuzz#5127 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate w3m. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.

At the moment I store the fuzzers in the Google OSS-Fuzz repository and we can keep it this way, however, it is preferred to have the fuzzers in upstream and that's why I have this PR. 