### PR TITLE
Kitty inline image & base64 encoding fixes

### DIFF
--- a/etc.c
+++ b/etc.c
@@ -2008,32 +2008,25 @@ void (*mySignal(int signal_number, void (*action) (int))) (int) {
 static char Base64Table[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-char *
+Str
 base64_encode(const unsigned char *src, size_t len)
 {
-    unsigned char *w, *at;
+    Str dest;
     const unsigned char *in, *endw;
     unsigned long j;
     size_t k;
 
-
-    if (!len)
-	return NULL;
-
     k = len;
     if (k % 3)
-      k += 3 - (k % 3);
+	k += 3 - (k % 3);
+
     k = k / 3 * 4;
 
-    if (k + 1 < len)
-	return NULL;
+    if (!len || k + 1 < len)
+	return Strnew();
 
-    w = GC_MALLOC_ATOMIC(k + 1);
-    if (!w)
-	return NULL;
-    w[k] = 0;
+    dest = Strnew_size(k);
 
-    at = w;
     in = src;
 
     endw = src + len - 2;
@@ -2043,30 +2036,28 @@ base64_encode(const unsigned char *src, size_t len)
 	j = j << 8 | *in++;
 	j = j << 8 | *in++;
 
-	*at++ = Base64Table[(j >> 18) & 0x3f];
-	*at++ = Base64Table[(j >> 12) & 0x3f];
-	*at++ = Base64Table[(j >> 6) & 0x3f];
-	*at++ = Base64Table[j & 0x3f];
+	Strcat_char(dest, Base64Table[(j >> 18) & 0x3f]);
+	Strcat_char(dest, Base64Table[(j >> 12) & 0x3f]);
+	Strcat_char(dest, Base64Table[(j >> 6) & 0x3f]);
+	Strcat_char(dest, Base64Table[j & 0x3f]);
     }
 
-    if (in - src - len) {
-	if (in - src - len == 1) {
-	    j = *in++;
-	    j = j << 8;
-	    j = j << 8;
-	    *at++ = Base64Table[(j >> 18) & 0x3f];
-	    *at++ = Base64Table[(j >> 12) & 0x3f];
-	    *at++ = '=';
-	    *at++ = '=';
-	} else {
-	    j = *in++;
+    if (src + len - in) {
+	j = *in++;
+	if (src + len - in) {
 	    j = j << 8 | *in++;
 	    j = j << 8;
-	    *at++ = Base64Table[(j >> 18) & 0x3f];
-	    *at++ = Base64Table[(j >> 12) & 0x3f];
-	    *at++ = Base64Table[(j >> 6) & 0x3f];
-	    *at++ = '=';
+	    Strcat_char(dest, Base64Table[(j >> 18) & 0x3f]);
+	    Strcat_char(dest, Base64Table[(j >> 12) & 0x3f]);
+	    Strcat_char(dest, Base64Table[(j >> 6) & 0x3f]);
+	} else {
+	    j = j << 8;
+	    j = j << 8;
+	    Strcat_char(dest, Base64Table[(j >> 18) & 0x3f]);
+	    Strcat_char(dest, Base64Table[(j >> 12) & 0x3f]);
+	    Strcat_char(dest, '=');
 	}
+	Strcat_char(dest, '=');
     }
-    return (char *)w;
+    return dest;
 }

--- a/file.c
+++ b/file.c
@@ -1179,11 +1179,7 @@ AuthBasicCred(struct http_auth *ha, Str uname, Str pw, ParsedURL *pu,
     Str s = Strdup(uname);
     Strcat_char(s, ':');
     Strcat(s, pw);
-    char *base64 = base64_encode(s->ptr, s->length);
-    if (!base64)
-	return Strnew_charp("Basic ");
-    else
-	return Strnew_m_charp("Basic ", base64, NULL);
+    return Strnew_m_charp("Basic ", base64_encode(s->ptr, s->length)->ptr, NULL);
 }
 
 #ifdef USE_DIGEST_AUTH

--- a/proto.h
+++ b/proto.h
@@ -829,4 +829,4 @@ void srand48(long);
 long lrand48(void);
 #endif
 
-extern char *base64_encode(const unsigned char *src, size_t len);
+extern Str base64_encode(const unsigned char *src, size_t len);


### PR DESCRIPTION
* base64_encode used to return a char buffer, I replaced this with a Str struct. This also means that Strcat_char does pointless bounds checking in this function which could be done once... no noticeable performance impact for me but if deemed necessary we could also write directly to the char pointer. Or use a gc_malloc'ed buffer as before, then call Strnew_charp.
* I fixed an oversight of mine where base64 padding could be applied incorrectly.
* Finally I changed the `convert` call to specify that ImageMagick should extract the first frame only from gifs. It otherwise extracted all frames for animations, which made w3m look for the wrong path.