### PR TITLE
Use libsixel fork with CVE fixes

### DIFF
--- a/doc/README.sixel
+++ b/doc/README.sixel
@@ -9,7 +9,7 @@ Introduction
 Requirements
 
   Install 'img2sixel' command provided by libsixel project.
-  (https://github.com/saitoha/libsixel)
+  (https://github.com/libsixel/libsixel)
 
 Build
 


### PR DESCRIPTION
`img2sixel` had two CVE's, and its maintainer disappeared. See saitoha/libsixel#154.

Myself and @dankamongmen are maintaining it now at libsixel/libsixel. Link to new repository.

Arch Linux etc. are distributing this version (libsixel 1.9+) now.