### PR TITLE
Ensure VLA size is at least one

### DIFF
--- a/table.c
+++ b/table.c
@@ -1263,8 +1263,8 @@ check_table_width(struct table *t, double *newwidth, MAT * minv, int itr)
     struct table_cell *cell = &t->cell;
 #ifdef __GNUC__
     short orgwidth[t->maxcol + 1], corwidth[t->maxcol + 1];
-    short cwidth[cell->maxcell + 1];
-    double swidth[cell->maxcell + 1];
+    short cwidth[cell->maxcell >= 0 ? cell->maxcell + 1 : 1];
+    double swidth[cell->maxcell >= 0 ? cell->maxcell + 1 : 1];
 #else				/* __GNUC__ */
     short orgwidth[MAXCOL], corwidth[MAXCOL];
     short cwidth[MAXCELL];
@@ -1629,7 +1629,7 @@ get_table_width(struct table *t, short *orgwidth, short *cellwidth, int flag)
 
     if (flag & CHECK_FIXED) {
 #ifdef __GNUC__
-	short ccellwidth[cell->maxcell + 1];
+	short ccellwidth[cell->maxcell >= 0 ? cell->maxcell + 1 : 1];
 #else				/* not __GNUC__ */
 	short ccellwidth[MAXCELL];
 #endif				/* not __GNUC__ */


### PR DESCRIPTION
Compiling with GCC 10.2 with -fsanitize=address,undefined valgrind
and opening the 'option panel' reports:
table.c:1632:8: runtime error: variable length array bound evaluates to non-positive value 0
table.c:1266:11: runtime error: variable length array bound evaluates to non-positive value 0
table.c:1267:12: runtime error: variable length array bound evaluates to non-positive value 0

'maxcell' is initialized to -1 which results in a size of 0 during the
first iteration. Though the array is only accessed if maxcell >= 0,
using a variable length array with a size < 1 is undefined behaviour
(see e.g. C99 6.7.5.2,p5).

This closes issue #51 .