### PR TITLE
Set `rc_dir` based on `W3M_DIR` environment variable.

### DIFF
--- a/doc/FAQ.html
+++ b/doc/FAQ.html
@@ -725,7 +725,7 @@ from Tatsuya Kinoshita <tats@debian.org>
    </dt>
    <dd>
     <p>
-     It is ~/.w3m/config.
+     By default, it is ~/.w3m/config.
     </p>
 
     <p>
@@ -733,6 +733,12 @@ from Tatsuya Kinoshita <tats@debian.org>
      the values of options whose effects are described in the options
      setting panel. Each line contains one option setting, consisting
      of an option name and its value with a space as a separator.
+    </p>
+
+    <p>
+     If the W3M_DIR environment variable is set to the name of a
+     directory, w3m will store its files in that directory instead of
+     in ~/.w3m.
     </p>
     
     <p>Without a user-specific configuration file, w3m honours

--- a/doc/MANUAL.html
+++ b/doc/MANUAL.html
@@ -92,6 +92,11 @@ insertions tagged with "mh 2016-03-29" and "mh 2016-06-11" come from the latest 
    there either then normally w3m will terminate.
   </p>
   <p>
+   You can change how w3m behaves by providing it with options, either
+   via the command line or through the configuration file. The user
+   config file is located at $W3M_DIR/config (~/.w3m/config by default).
+  </p>
+  <p>
    Options include:
   </p>
   <dl>

--- a/doc/w3m.1
+++ b/doc/w3m.1
@@ -266,9 +266,16 @@ $ w3m \-v
 .EE
 .\".SH Errors
 .SH ENVIRONMENT
-\fIw3m\fP recognises the environment variable WWW_HOME as defining a
-fallback target for use if it is invoked without one.
+\fIw3m\fP recognises the environment variable \fBWWW_HOME\fP as
+defining a fallback target for use if it is invoked without one.
+
+If the \fBW3M_DIR\fP environment variable is set to a directory
+name, \fIw3m\fP will store its user files there instead of
+under the ~/.w3m directory.
 .SH FILES
+The default locations of some files are listed below. These
+locations can be altered via the \fBW3M_DIR\fP environment
+variable.
 .TP
 \f(CW~/.w3m/bookmark.html\fP
 default bookmark file

--- a/rc.c
+++ b/rc.c
@@ -1248,9 +1248,7 @@ do_recursive_mkdir(const char *dir)
     if (*dir == '\0')
 	 return -1;
 
-    if ((dircpy = strdup(dir)) == NULL)
-	 return -1; 
-
+    dircpy = Strnew_charp(dir)->ptr; 
     ch = dircpy + 1;
     do {
 	while (!(*ch == '/' || *ch == '\0')) {
@@ -1262,30 +1260,26 @@ do_recursive_mkdir(const char *dir)
 
 	if (stat(dircpy, &st) < 0) {
 	    if (errno != ENOENT) {	/* no directory */
-		goto err;
+		return -1; 
 	    }
 	    if (do_mkdir(dircpy, 0700) < 0) {
-		goto err;
+		return -1; 
 	    }
 	    stat(dircpy, &st);
 	}
 	if (!S_ISDIR(st.st_mode)) {
 	    /* not a directory */
-	    goto err;
+	    return -1; 
 	}
 	if (!(st.st_mode & S_IWUSR)) {
-	    goto err;
+	    return -1; 
 	}
 
 	*ch = tmp;
 
     } while (*ch++ != '\0');
 
-    free(dircpy);
     return 0;
-err:
-    free(dircpy);
-    return -1;
 }
 
 static void loadSiteconf(void);

--- a/rc.c
+++ b/rc.c
@@ -1245,13 +1245,11 @@ do_recursive_mkdir(const char *dir)
     size_t n;
     struct stat st;
 
-    n = strlen(dir);
-    if (n == 0)
+    if (*dir == '\0')
 	 return -1;
 
-    if ((dircpy = malloc(n + 1)) == NULL)
-	 return -1;
-    strcpy(dircpy, dir);
+    if ((dircpy = strdup(dir)) == NULL)
+	 return -1; 
 
     ch = dircpy + 1;
     do {


### PR DESCRIPTION
By default, w3m puts all of its data in the `~/.w3m/` directory (creating it as necessary). This was not configurable in any way.

This commit addresses this problem. When the `W3M_DIR` environment variable is set, w3m will use its contents to store its data files instead. The default location is unchanged.

This PR should resolve issue #130. Sorry for the delay :)