### PR TITLE
fix wc_map_range_search() parameter type mismatch

### DIFF
--- a/libwc/search.c
+++ b/libwc/search.c
@@ -51,7 +51,7 @@ wc_map3_search(wc_uint16 c1, wc_uint16 c2, wc_map3 *map, size_t n)
 }
 
 wc_map *
-wc_map_range_search(wc_uint16 code, wc_map *map, int n)
+wc_map_range_search(wc_uint16 code, wc_map *map, size_t n)
 {
     return (wc_map *)bsearch((void *)&code, (void *)map, n, sizeof(wc_map),
 	map_range_cmp);


### PR DESCRIPTION
caught by trying to compile on gcc with LTO enabled