### PR TITLE
Do not use imlib2-config

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -693,9 +693,6 @@ AC_DEFUN([AC_W3M_IMAGE],
      with_imlib2="yes"
      if test x"$PKG_CONFIG" = x; then
        PKG_CONFIG=pkg-config
-     fi
-     if test x"$IMLIB2_CONFIG" = x; then
-       IMLIB2_CONFIG=imlib2-config
      fi;;
    gdk-pixbuf)
      with_gdkpixbuf="yes"
@@ -736,7 +733,7 @@ AC_DEFUN([AC_W3M_IMAGE],
   fi
   if test x"$with_imlib2" = xyes; then
    AC_W3M_CHECK_VER([Imlib2],
-	[`$IMLIB2_CONFIG --version 2>/dev/null`],
+	[`$PKG_CONFIG --modversion imlib2 2>/dev/null`],
 	1, 0, 5,
 	[have_imlib2="yes"],
 	[have_imlib2="no"])
@@ -747,7 +744,7 @@ AC_DEFUN([AC_W3M_IMAGE],
      IMGOBJS="$IMGOBJS x11/x11_w3mimg.o"
      IMGTARGETS="x11"    
      AC_DEFINE(USE_IMLIB2)
-     IMGX11CFLAGS="`${IMLIB2_CONFIG} --cflags`"
+     IMGX11CFLAGS="`${PKG_CONFIG} --cflags imlib2`"
      IMGX11LDFLAGS="-lX11 `${PKG_CONFIG} --libs imlib2`"
    elif test x"$have_gtk2" = xyes; then
      AC_DEFINE(USE_W3MIMG_X11)
@@ -783,7 +780,7 @@ AC_DEFUN([AC_W3M_IMAGE],
      IMGTARGETS="${IMGTARGETS} fb"
      AC_DEFINE(USE_IMLIB2)
      IMGOBJS="$IMGOBJS fb/fb_w3mimg.o fb/fb.o fb/fb_img.o"
-     IMGFBCFLAGS="`${IMLIB2_CONFIG} --cflags`"
+     IMGFBCFLAGS="`${PKG_CONFIG} --cflags imlib2`"
      IMGFBLDFLAGS="`${PKG_CONFIG} --libs imlib2`"
    elif test x"$have_gtk2" = xyes; then
      AC_DEFINE(USE_W3MIMG_FB)

--- a/configure
+++ b/configure
@@ -7544,9 +7544,6 @@ $as_echo "$with_imagelib" >&6; }
      with_imlib2="yes"
      if test x"$PKG_CONFIG" = x; then
        PKG_CONFIG=pkg-config
-     fi
-     if test x"$IMLIB2_CONFIG" = x; then
-       IMLIB2_CONFIG=imlib2-config
      fi;;
    gdk-pixbuf)
      with_gdkpixbuf="yes"
@@ -7628,7 +7625,7 @@ $as_echo "$as_me: WARNING: Imlib is not installed.  Install Imlib (version >= 1.
  fi
   fi
   if test x"$with_imlib2" = xyes; then
-   version="`$IMLIB2_CONFIG --version 2>/dev/null`"
+   version="`$PKG_CONFIG --modversion imlib2 2>/dev/null`"
  if test x"$version" != x; then
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking Imlib2 version" >&5
 $as_echo_n "checking Imlib2 version... " >&6; }
@@ -7656,7 +7653,7 @@ $as_echo "$as_me: WARNING: Imlib2 is not installed.  Install Imlib2 (version >= 
      IMGTARGETS="x11"
      $as_echo "#define USE_IMLIB2 1" >>confdefs.h
 
-     IMGX11CFLAGS="`${IMLIB2_CONFIG} --cflags`"
+     IMGX11CFLAGS="`${PKG_CONFIG} --cflags`"
      IMGX11LDFLAGS="-lX11 `${PKG_CONFIG} --libs imlib2`"
    elif test x"$have_gtk2" = xyes; then
      $as_echo "#define USE_W3MIMG_X11 1" >>confdefs.h
@@ -7702,7 +7699,7 @@ $as_echo "$as_me: WARNING: unable to build w3mimgdisplay with X11 support" >&2;}
      $as_echo "#define USE_IMLIB2 1" >>confdefs.h
 
      IMGOBJS="$IMGOBJS fb/fb_w3mimg.o fb/fb.o fb/fb_img.o"
-     IMGFBCFLAGS="`${IMLIB2_CONFIG} --cflags`"
+     IMGFBCFLAGS="`${PKG_CONFIG} --cflags`"
      IMGFBLDFLAGS="`${PKG_CONFIG} --libs imlib2`"
    elif test x"$have_gtk2" = xyes; then
      $as_echo "#define USE_W3MIMG_FB 1" >>confdefs.h


### PR DESCRIPTION
imlib2-config was dropped by Imlib2:
https://git.enlightenment.org/legacy/imlib2.git/commit/?id=e9d84bd2163e6fab494b5ce5cc8830a54ff97765

The fixes issue #213.