### PR TITLE
[RFC] fix -Wdiscarded-qualifiers warning

### DIFF
--- a/istream.c
+++ b/istream.c
@@ -418,7 +418,7 @@ ssl_check_cert_ident(X509 * x, char *hostname)
 	if (alt) {
 	    int n;
 	    GENERAL_NAME *gn;
-	    X509V3_EXT_METHOD *method;
+	    const X509V3_EXT_METHOD *method;
 	    Str seen_dnsname = NULL;
 
 	    n = sk_GENERAL_NAME_num(alt);


### PR DESCRIPTION
Hi, I looked into this because of the following warning:

```console
istream.c:447:20: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  447 |             method = X509V3_EXT_get(ex);
      |                    ^
```

Simply adding `const` to `method` seems to compile fine, but it looks like that the pointer isn't even being used. So I'm not sure what's going on here, so my patch is possibly incorrect. Would appreciate if someone can take a look here.