### PR TITLE
Ignore tokens that look like HTML, but are not

### DIFF
--- a/file.c
+++ b/file.c
@@ -6523,6 +6523,7 @@ HTMLlineproc0(char *line, struct html_feed_environ *h_env, int internal)
 		    line = Strnew_m_charp(p, line, NULL)->ptr;
 		}
 		is_tag = FALSE;
+		continue;
 	    }
 	    if (obuf->table_level >= 0)
 		goto proc_normal;


### PR DESCRIPTION
This patch fixes issue 200 'heap-buffer-overflow in
shiftAnchorPosition'.

Any input that looks like a tag, but isn't, should just be ignored. HTML
is parsed in a two staged process. Stage 1 inserts internal tags (like
<a hseq=...>). Stage 2 assumes these internal tags are valid input
inserted in the previous stage. If we don't throw away non-valid HTML
tags in stage 1 any website can inject tags that are interpreted as
internal ones. This leads to an out-of-bound read in this test case.

The 'hseq=-90' from the input ends as the value (89 actually) of
'a->hseq' in 'anchor.c:555'. Then 'hl->marks[a->hseq]' is out of bounds
as there are only 30 entries in this list.

This is the test input:
<table>0<br <>0<xmp>È«<div><inteRnal><input_alt fid=0><dl>0<dl>0<button value='">0000000000000000000000000000000000000000ÿ000'><A hseq=-90 href=>0<hR align=middle>