### PR TITLE
Check for end of string when parsing Gopher URLs

### DIFF
--- a/url.c
+++ b/url.c
@@ -978,7 +978,10 @@ parseURL(char *url, ParsedURL *p_url, ParsedURL *current)
     }
 #ifdef USE_GOPHER
     if (p_url->scheme == SCM_GOPHER && *p == 'R') {
-	p++;
+	if (!*++p) {
+	    p_url->file = "";
+	    goto do_query;
+	}
 	tmp = Strnew();
 	Strcat_char(tmp, *(p++));
 	while (*p && *p != '/')


### PR DESCRIPTION
This fixes issue #199 reported by Kuang-che Wu.

A specially crafted Gopher URL (e.g. '<a href=gopher:R>') could lead to
an out-of-bounds read.

Problem here was, that 'p' was incremented twice without checking for
the end of the string.

The interesting question for me is: What does this 'if' actually check?
What is special here about the 'R'? I did not find anything related in
RFC 1436 or in RFC 4266.