### PR TITLE
Add option to set directory for temporary files

### DIFF
--- a/etc.c
+++ b/etc.c
@@ -1662,7 +1662,7 @@ url_unquote_conv0(char *url)
 }
 
 static char *tmpf_base[MAX_TMPF_TYPE] = {
-    "tmp", "src", "frame", "cache", "cookie",
+    "tmp", "src", "frame", "cache", "cookie", "hist",
 };
 static unsigned int tmpf_seq[MAX_TMPF_TYPE];
 
@@ -1670,8 +1670,23 @@ Str
 tmpfname(int type, char *ext)
 {
     Str tmpf;
+    char *dir;
+
+    switch(type) {
+    case TMPF_HIST:
+	dir = rc_dir;
+	break;
+    case TMPF_DFL:
+    case TMPF_COOKIE:
+    case TMPF_SRC:
+    case TMPF_FRAME:
+    case TMPF_CACHE:
+    default:
+	dir = tmp_dir;
+    }
+
     tmpf = Sprintf("%s/w3m%s%d-%d%s",
-		   tmp_dir,
+		   dir,
 		   tmpf_base[type],
 		   CurrentPid, tmpf_seq[type]++, (ext) ? ext : "");
     pushText(fileToDelete, tmpf->ptr);

--- a/fm.h
+++ b/fm.h
@@ -812,7 +812,8 @@ typedef struct http_request {
 #define TMPF_FRAME	2
 #define TMPF_CACHE	3
 #define TMPF_COOKIE	4
-#define MAX_TMPF_TYPE	5
+#define TMPF_HIST	5
+#define MAX_TMPF_TYPE	6
 
 #define set_no_proxy(domains) (NO_proxy_domains=make_domain_list(domains))
 

--- a/history.c
+++ b/history.c
@@ -64,7 +64,7 @@ saveHistory(Hist *hist, size_t size)
 
     if (hist == NULL || hist->list == NULL)
 	return;
-    tmpf = tmpfname(TMPF_DFL, NULL)->ptr;
+    tmpf = tmpfname(TMPF_HIST, NULL)->ptr;
     if ((f = fopen(tmpf, "w")) == NULL) {
 	/* FIXME: gettextize? */
 	disp_err_message("Can't open history", FALSE);

--- a/rc.c
+++ b/rc.c
@@ -127,6 +127,7 @@ static int OptionEncode = FALSE;
 #define CMT_DROOT       N_("Directory corresponding to / (document root)")
 #define CMT_PDROOT      N_("Directory corresponding to /~user")
 #define CMT_CGIBIN      N_("Directory corresponding to /cgi-bin")
+#define CMT_TMP         N_("Directory for temporary files")
 #define CMT_CONFIRM_QQ  N_("Confirm when quitting with q")
 #define CMT_CLOSE_TAB_BACK N_("Close tab if buffer is last when back")
 #ifdef USE_MARK
@@ -580,6 +581,7 @@ struct param_ptr params5[] = {
      (void *)&personal_document_root, CMT_PDROOT, NULL},
     {"cgi_bin", P_STRING, PI_TEXT, (void *)&cgi_bin, CMT_CGIBIN, NULL},
     {"index_file", P_STRING, PI_TEXT, (void *)&index_file, CMT_IFILE, NULL},
+    {"tmp_dir", P_STRING, PI_TEXT, (void *)&tmp_dir, CMT_TMP, NULL},
     {NULL, 0, 0, NULL, NULL, NULL},
 };
 


### PR DESCRIPTION
With this patch applied the user can configure a directory to store
temporary/cache files. The history and cookies remain in RC_DIR.

I suppose the intent of writing the history to a temp file first is to
make the actual write an atomic operation. As rename() does not work
across mount points, we need to handle the temp file for the history
different to keep this behaviour.

Add a new type for the temp history file and handle this case different
when creating a temp file.