### PR TITLE
Fix some more warnings

### DIFF
--- a/libwc/wtf.c
+++ b/libwc/wtf.c
@@ -120,7 +120,7 @@ int
 wtf_strwidth(wc_uchar *p)
 {
     int w = 0;
-    wc_uchar *q = p + strlen(p);
+    wc_uchar *q = p + strlen((char *)p);
 
     while (p < q) {
 	w += wtf_width(p);
@@ -146,7 +146,7 @@ size_t
 wtf_len(wc_uchar *p)
 {
     wc_uchar *q = p;
-    wc_uchar *strz = p + strlen(p);
+    wc_uchar *strz = p + strlen((char *)p);
 
     q += WTF_LEN_MAP[*q];
     while (q < strz && ! WTF_WIDTH_MAP[*q])

--- a/w3mimg/x11/x11_w3mimg.c
+++ b/w3mimg/x11/x11_w3mimg.c
@@ -698,8 +698,8 @@ static int
 x11_get_image_size(w3mimg_op * self, W3MImage * img, char *fname, int *w,
 		   int *h)
 {
-    struct x11_info *xi;
 #if defined(USE_IMLIB)
+    struct x11_info *xi;
     ImlibImage *im;
 #elif defined(USE_IMLIB2)
     Imlib_Image im;


### PR DESCRIPTION
Fix some more warnings

commit beb07d24bc90ef25014d2a4776e0b73528ca5458
Author: Rene Kita <mail@rkta.de>
Date:   2021-12-28T17:10:44+01:00

    Fix a warning about an unused variable

    *xi is only used if USE_IMLIB is defined, move the declaration inside
    the #ifdef block.

 w3mimg/x11/x11_w3mimg.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit 6d1a8d44e218ccd8f80b2981a59437fa276a1ef9
Author: Rene Kita <mail@rkta.de>
Date:   2021-12-28T17:09:56+01:00

    Cast away a warning

    strlen() takes a char *, but p is a unsigned char *.

 libwc/wtf.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)