### PR TITLE
Minor Fixes of English Docs

### DIFF
--- a/doc/README.SSL
+++ b/doc/README.SSL
@@ -1,0 +1,52 @@
+Support for SSL
+                                                   (2000/11/07) Katsunari Okabe
+                                                        okabek@guitar.ocn.ne.jp
+                                                   (2001/12/27)  Fumitoshi Ukai
+                                                              ukai@debian.or.jp
+
+
+* Install the OpenSSL Library before building w3m
+   to provide SSL support.
+
+* The configure script can automatically detect if the
+   OpenSSL Library has been installed. If the script does
+   not run, confirm the USE_SSL macro has been defined in
+   config.h. Furthermore, if you want to enable SSL support
+   confirm that the USE_SSL_VERIFY macro has been defined as well.
+   If the compiler throws an error, confirm the `-lssl -lcrypto`
+   linker flags are set, as well as the '-I(SSLeay/OpenSSL
+   header directory)` flag.
+
+   SSL Support can be validated from the "SSL Settings" section
+   of the Option Setting Panel.
+
+ * The following settings are available for SSL:
+
+   ssl_forbid_method
+       List of methods you can forbid (2: SSLv2: 3: SSLv3, t: TLSv1.0,
+       5: TLSv1.1, 6: TLSv1.2, 7: TLSv1.3)
+       (default is 2, 3, t, 5)
+   ssl_min_version
+       Lowest SSL Version, OpenSSL 1.1 and later, options are: (all,
+       TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3) (default is not set)
+   ssl_cipher
+       Prior to TLSv1.2 the SSL cipher (example: DEFAULT:@SECLEVEL=2)
+       (default for OpenSSL 1.1 and later is not set.
+       Otherwise DEFAULT:!LOW:!RC4:!EXP).
+   ssl_verify_server ON/OFF
+       Verify the SSL server (default: ON)
+   ssl_cert_file filename
+       SSL client PEM certificate (default is not set)
+   ssl_key_file
+       SSL client PEM secret key (default is not set)
+   ssl_ca_path directory
+       SSL CA PEM certificate directory (default is not set)
+   ssl_ca_file filename
+       SSL CA PEM certificate filename (default is not set,
+       set when you run the configure script)
+   ssl_ca_default ON/OFF
+       Use the standard location for the SSL CA PEM certificate file
+       (default ON)
+
+ * If your environment uses the EGD (Entropy Gathering Daemon),
+   please check the USE_EGD macro.

--- a/doc/README.cookie
+++ b/doc/README.cookie
@@ -9,15 +9,18 @@ cookie support of w3m
    http://www.ics.uci.edu/pub/ietf/http/draft-ietf-http-state-man-mec-12.txt)
    cookie.
    
- * If you want to disable cookie support, run the configure script with
+ * Cookie support is enabled by default in the configure script. If the
+    configure script will not run, check that the USE_COOKIE macro is
+    defined in config.h
+    If you want to disable cookie support, run the configure script with
     --disable-cookie option.
    
- * You can choose to use cookies or not on the Option Setting Panel or
-   -cookie and -no-cookie option.
+ * You can choose whether or not to use cookies from the Option Setting Panel
+    (normally bound to 'o') or -cookie and -no-cookie option.
    
- * You can disable cookies on the Option Setting Panel. In this case
-    all new cookies are rejected, however, cookies which were accepted before
-    cookies were disabled are used.
+ * You can disable cookies on the Option Setting Panel. When you do this,
+    all new cookies will be rejected, however, cookies which were accepted
+    before cookies were disabled will continue to be used.
    
  * You can see the list of accepted cookies with C-k. In this panel, you
     can choose to use each cookie or not.
@@ -36,6 +39,18 @@ cookie support of w3m
 
                               (HDN: host domain name)
 
+For the following example, if the cookies for selected domain (.xxx.or.jp)
+will be accepted then the settings would look like the following:
+┌────────────────────────────────────┐
+|Cookie Settings                     |
+|                                    |
+|Use Cookies            (*)ON ( )OFF |
+|Accept Cookies         (*)ON ( )OFF |
+|Use Problematic Cookies [discard]   |
+|Reject Cookie Domain [.          ]  |
+|Accept Cookie Domain [.xxx.or.jp ]  |
+|                         [OK]       |
+└────────────────────────────────────┘
 
  * If the number of "." in domain name is fewer than 2, it is
     assumed as invalid cookie (cf. RFC 2109 4.3.2), however, you can

--- a/doc/README.func
+++ b/doc/README.func
@@ -1,4 +1,4 @@
-ABORT		Quit at once
+ABORT		Quit without confirmation
 ACCESSKEY	Pop up accesskey menu
 ADD_BOOKMARK	Add current page to bookmarks
 ALARM		Set alarm
@@ -28,7 +28,7 @@ EDIT		Edit local source
 EDIT_SCREEN	Edit rendered copy of document
 END		Go to the last line
 EXEC_SHELL	Execute shell command and display output
-EXIT		Quit at once
+EXIT		Quit without confirmation
 EXTERN		Display using an external browser
 EXTERN_LINK	Display target using an external browser
 FRAME		Toggle rendering HTML frames
@@ -38,7 +38,7 @@ GOTO_LINE	Go to the specified line
 GOTO_LINK	Follow current hyperlink in a new buffer
 GOTO_RELATIVE	Go to relative address
 HELP		Show help panel
-HISTORY 	Show browsing history
+HISTORY		Show browsing history
 INFO		Display information about the current document
 INTERRUPT	Suspend w3m to background
 ISEARCH 	Incremental search forward

--- a/doc/README.img
+++ b/doc/README.img
@@ -76,7 +76,7 @@ Option panel
       Scale of image (%). The default value is 100(%).
   imgdisplay
       External command to display image. The default value is "w3mimgdisplay".
-      See "Setting w3mimgdisplay."
+      See "w3mimgdisplay Settings" section
 
 Required programs
 
@@ -89,8 +89,8 @@ Required programs
       http://w3m.sourceforge.net/
       http://sourceforge.net/projects/w3m/
       http://prdownloads.sourceforge.net/w3m/
-    * Imlib-1.9.8 (1.9.10 is recommendable.)
-      libungif-4.1.0b1 is recommendable.
+    * Imlib-1.9.8 (1.9.10 or later is recommended.)
+    * libungif-4.1.0b1 or later is recommended.
 
   for Linux framebuffer device
     * GdkPixbuf-0.16 or later
@@ -103,7 +103,7 @@ Required programs
       and 16/24/32 bpp truecolor/directcolor)
 
 
-Setting w3mimgdisplay
+w3mimgdisplay Settings
 
   "w3mimgdisplay" has the following options. Set options to fit terminal.
 
@@ -134,7 +134,7 @@ Setting w3mimgdisplay
     w3m -o 'imgdisplay=w3mimgdisplay -x 5 -bg "#cccccc"'
 
 Notice
-    If you want to see GIF animation, please hit a suitable key, such
+    If you want to see GIF animation, please hit a movement key, such
     as 'h', 'l', etc., repeatedly, because a new frame is only requested
     according to the re-drawing demand from w3m.
 
@@ -145,7 +145,7 @@ Notice
     and PuTTY.
 
 
-Change log
+Changelog
 
 2002/02/04
  * Revised this document.

--- a/doc/README.keymap
+++ b/doc/README.keymap
@@ -1,0 +1,52 @@
+Keyboard Support for w3m
+                                                 (1999/06/30) H. Sakamoto
+                                                  hsaka@mth.biglobe.ne.jp
+
+Keyboard settings are located in ~/.w3m/keymap.
+Settings are designated by:
+
+    keymap key command [argument]
+
+Ex. See: keymap.default and keymap.lynx
+Command settings can be seen in README.func
+
+Multi-character escape sequences are designated by:
+    Escape letter
+    Escape [ letter, Escape O letter
+    Escape [ number ~, EScape [ number number ~
+
+Special characters are represented as:
+
+    Ctrl     : C-, ^
+    Escape   : ESC-, M-, \e, ^[
+    Space    : SPC, ' '
+    Tab      : AB, \t, ^i, ^I
+    Delete   : DEL, ^?
+    BackSpace: \b, ^h, ^H
+    NewLine  : \n, ^j, ^J
+    Return   : \r, ^m, ^M
+    Bell     : \a, ^g, ^G
+    Up       : UP, ^[[A
+    Down     : DOWN, ^[[B
+    Right    : RIGHT, ^[[C
+    Left     : LEFT, ^[[D
+    ^        : \^
+
+Also, terminal commands are can be used by:
+
+    Insert  : ^[[2~
+    PageUp  : ^[[5~
+    PageDown: ^[[6~
+    F1      : ^[[11~
+    F2      : ^[[12~
+    F3      : ^[[13~
+    F4      : ^[[14~
+    F5      : ^[[15~
+    F6      : ^[[17~
+    F7      : ^[[18~
+    F8      : ^[[19~
+    F9      : ^[[20~
+    F10     : ^[[21~
+    Help    : ^[[28~
+
+(Confirm for each keyboard using Ctrl-V + key.)

--- a/doc/README.m17n
+++ b/doc/README.m17n
@@ -5,15 +5,16 @@ Muntilingualizaion of w3m
 
 Introduction
 
-  I have tried the muntilingualization of w3m (w3m-m17n).
+  I have tried the multilingualization of w3m (w3m-m17n).
   The patch for w3m-0.4.1 is available on the following site.
 
     http://www2u.biglobe.ne.jp/~hsaka/w3m/index.html#m17n
                                           patch/w3m-0.4.1-m17n-20030308.tar.gz
                                           patch/README.m17n
 
-  It is a development version. And enough test is not preformed because
-  I can understand Japanese only. Please use, test, and report bugs.
+  This is a development version, and should be enough to test.
+  I can understand Japanese only, so please use this version, test it,
+  and report bugs.
 
   Now, w3m-m17n has following functions.
 
@@ -156,11 +157,11 @@ Option pannel
    display_charset
        Display charset.
    document_charset
-       Defalut Document charset.
+       Default Document charset.
    auto_detect
-       Automatic charset detect when loading. (Default: ON)
+       Automatic charset detection when loading. (Default: ON)
    system_charset
-       System charset. It is used for configuration files and file name.
+       System charset. It is used for configuration files and file names.
    follow_locale
        System charset follows locale($LANG). (Default: ON)
    ext_halfdump
@@ -168,7 +169,7 @@ Option pannel
    search_conv
        Adjust search string for document charset. (Default: ON)
    use_wide
-       Use multi column characters. (Default: ON)
+       Use multi-column characters. (Default: ON)
    use_combining
        Use combining characters. (Default: ON)
    use_language_tag
@@ -178,7 +179,7 @@ Option pannel
    pre_conv
        Charset conversion when loading. (Default: OFF)
    fix_width
-       Fix character width when conversion. (Default: ON)
+       Fix character width when converting. (Default: ON)
        If it is OFF, the rendering may collapse.
    use_gb12345_map
        Use GB 12345 Unicode map instead of GB 2312's. (Default: OFF)

--- a/doc/README.menu
+++ b/doc/README.menu
@@ -1,0 +1,105 @@
+w3m menu options
+                                                 (2002/11/27)  H. Sakamoto
+                                                   hsaka@mth.biglobe.ne.jp
+
+[1] Hotkeys
+
+  * General Purpose
+
+    HELP, INS key             : open menu
+    HELP, INS key, C-c,       : close menu
+    RET(C-m, C-j), SPC, right-key : select
+    BS(C-h), DEL(C-?), left-key   : go back
+    C-n, j, down-key           : go to lower selection
+    C-p, k, up-key             : go to upper selection
+    J                          : scroll down
+    K                          : scroll up
+    C-a                        : previous heading
+    C-e                        : next heading
+    C-f, C-v                   : next page
+    C-b, M-v                   : last page
+    C-s, /                     : search down
+    C-r, ?                     : search up
+    n                          : search for next
+    N                          : search for previous
+    C-z                        : suspend
+
+    # INS is normally ^[[2~ but is bound to ^[[L(console), ^[[E(PocketBSD).
+
+    MenuKeymap, MenuEscKeymap, MenuEscBKeymap, MenuEscDKeymap are defined
+     in (menu.c)
+
+  * Special Case
+
+    MenuItem structure (menu.h) is set as (possibly multiple)
+     char * keys
+     from the keys listed above.
+
+[2] Mouse
+
+    Button 3: open menu
+
+  After opening the menu
+
+    button 1/3 (heading)         : select
+    button 1/3 (frame, MENU_NOP) : nothing
+    button 1/3 (outside menu)    : go back (close menu)
+    button 1/3 ( : )             : next page or prev page heading
+                                    (in case of long menu)
+    button 1/3 (drag)            : scroll
+
+[3] menu customization
+
+   menu is defined in ~/.w3m/menu
+   menu is
+
+     menu MENU_ID
+      heading
+        :
+     end
+
+  For settings, every heading is
+
+     func  LABEL FUNCTION KEYS [DATA]	//command execution
+     popup LABEL MENU_ID  KEYS		//open sub-menu
+     nop   LABEL			//no action (separator or title)
+
+  are possible settings.
+  Look at menu.defualt and menu.submenu for examples.
+   Look at README.func for setting commands (FUNCTION).
+  For MENU_ID "Main" is the main menu, "Select" is buffer
+   choice menu, "SelectTab" is the tab selection menu.
+   For KEYS, the key to be bound to the menu.
+   For DATA, set the command (FUNCTION) arguments.
+
+[4] Development
+
+    See Below to understand menu routines such as mainMenu(),
+     optionMenu() etc.
+     The MenuItem routine structure is defined below, almost
+     all menus are constructed like this.
+
+   MenuItem 構造体 (menu.h)
+
+    struct {
+        int  type;		/* type */
+        char *label;		/* label */
+        int  *variable;		/* VALUE_MENU variable settings */
+        int  value;		/* VALUE_MENU variable value */
+        void (*func)();		/* function choice */
+        struct _Menu *popup;	/* submenu */
+        char *keys;		/* bound keys */
+    } MenuItem;
+
+   Type "type" used below.
+
+     MENU_NOP   (1) : No action, no setting.
+                      (title and separator)
+     MENU_FUNC  (2) : function execution
+     MENU_VALUE (4) : (*variable) and (value) setting
+     MENU_POPUP (8) : submenu to open
+
+     MENU_FUNC and MENU_VALUE are (MENU_FUNC | MENU_VALUE) and
+      need to be set together。(variable needs to be set)
+
+   Example of MainMenuItem and new_option_menu() can be seen in (menu.c).

--- a/doc/README.passwd
+++ b/doc/README.passwd
@@ -1,21 +1,21 @@
-You can save your passwords and usernames for a web page which require
+You can save your passwords and usernames for web pages that require
 HTTP certification or a proxy certification.
 
-The configuration file is designated in "passwd_file" parameter. The
-format of the configuration file is as follows
+The configuration file is designated in the "passwd_file" parameter.
+The format of the configuration file is as follows
 
 machine hostname
-port port number
-path local part
-realm realm string
-login username
-passwd password
+port    port number
+path    local part
+realm   realm string
+login   username
+passwd  password
 proxy
 
-Each configuration is began with machine and ended before the next machine.
+Each configuration begins with machine and ends at the next machine.
 You can omit port, path and realm.
 
-proxy means settings for proxy certification.
+proxy designates settings for proxy certification.
 
 If passwd_file is readable from other users, w3m shows a warning for
 that.  If you can not set the permission for the passwd_file because


### PR DESCRIPTION
* Translating Documentation

* Create README.SSL from doc-jp

* Clarified wording on some functions

* Clarified English in README.img

* Created README.keymap

* Translated README.menu

* Minor grammar changes