### PR TITLE
For sixel, no need to round image size to multiple of character size.

### DIFF
--- a/image.c
+++ b/image.c
@@ -253,7 +253,9 @@ drawImage()
 
 
 	    if (enable_inline_image == INLINE_IMG_SIXEL) {
-		put_image_sixel(url, x, y, w, h, sx, sy, sw, sh, n_terminal_image);
+		w = i->cache->a_width > 0 ? i->width : 0;
+		h = i->cache->a_height > 0 ? i->height : 0;
+		put_image_sixel(url, x, y, w, h, i->sx, i->sy, sw * pixel_per_char, sh * pixel_per_line_i, n_terminal_image);
 	    } else if (enable_inline_image == INLINE_IMG_OSC5379) {
 		put_image_osc5379(url, x, y, w, h, sx, sy, sw, sh);
 	    } else if (enable_inline_image == INLINE_IMG_ITERM2) {

--- a/terms.c
+++ b/terms.c
@@ -824,14 +824,13 @@ put_image_sixel(char *url, int x, int y, int w, int h, int sx, int sy, int sw, i
 	argv[n++] = "-l";
 	argv[n++] = do_anim ? "auto" : "disable";
 	argv[n++] = "-w";
-	sprintf(digit[0], "%d", w*pixel_per_char_i);
+	sprintf(digit[0], "%d", w);
 	argv[n++] = digit[0];
 	argv[n++] = "-h";
-	sprintf(digit[1], "%d", h*pixel_per_line_i);
+	sprintf(digit[1], "%d", h);
 	argv[n++] = digit[1];
 	argv[n++] = "-c";
-	sprintf(clip, "%dx%d+%d+%d", sw*pixel_per_char_i, sh*pixel_per_line_i,
-			sx*pixel_per_char_i, sy*pixel_per_line_i);
+	sprintf(clip, "%dx%d+%d+%d", sw, sh, sx, sy);
 	argv[n++] = clip;
 	argv[n++] = url;
 	if (getenv("TERM") && strcmp(getenv("TERM"), "screen") == 0 &&


### PR DESCRIPTION
With this fix combined with fix to libsixel:

https://github.com/saitoha/libsixel/pull/170

browsing on slow machines (e.g., when floating-point calculation is
emulated by kernel) gets significantly speed up.

Note that if i->cache->a_width (i->cache->a_height) is zero, width
(height) should be set to zero. Otherwise, image in screen boundary
(i.e., partially displayed) becomes strangely resized.