### PR TITLE
Do not override history file if it was changed

### DIFF
--- a/history.c
+++ b/history.c
@@ -87,6 +87,11 @@ fail:
 }
 #endif				/* USE_HISTORY */
 
+/*
+ * The following functions are used for internal stuff, we need them regardless
+ * if history is used or not.
+ */
+
 Hist *
 newHist(void)
 {

--- a/history.c
+++ b/history.c
@@ -31,16 +31,16 @@ historyBuffer(Hist *hist)
     return loadHTMLString(src);
 }
 
-void
+int
 loadHistory(Hist *hist)
 {
     FILE *f;
     Str line;
 
     if (hist == NULL)
-	return;
+	return 1;
     if ((f = fopen(rcFile(HISTORY_FILE), "rt")) == NULL)
-	return;
+	return 1;
 
     while (!feof(f)) {
 	line = Strfgets(f);
@@ -52,6 +52,7 @@ loadHistory(Hist *hist)
 	pushHist(hist, url_quote(line->ptr));
     }
     fclose(f);
+    return 0;
 }
 
 void

--- a/history.c
+++ b/history.c
@@ -65,26 +65,24 @@ saveHistory(Hist *hist, size_t size)
     if (hist == NULL || hist->list == NULL)
 	return;
     tmpf = tmpfname(TMPF_HIST, NULL)->ptr;
-    if ((f = fopen(tmpf, "w")) == NULL) {
-	/* FIXME: gettextize? */
-	disp_err_message("Can't open history", FALSE);
-	return;
-    }
+    if ((f = fopen(tmpf, "w")) == NULL)
+	goto fail;
     for (item = hist->list->first; item && hist->list->nitem > size;
 	 item = item->next)
 	size++;
     for (; item; item = item->next)
 	fprintf(f, "%s\n", (char *)item->ptr);
-    if (fclose(f) == EOF) {
-	/* FIXME: gettextize? */
-	disp_err_message("Can't save history", FALSE);
-	return;
-    }
+    if (fclose(f) == EOF)
+	goto fail;
     rename_ret = rename(tmpf, rcFile(HISTORY_FILE));
-    if (rename_ret != 0) {
-	disp_err_message("Can't save history", FALSE);
-	return;
-    }
+    if (rename_ret != 0)
+	goto fail;
+
+    return;
+
+fail:
+    disp_err_message("Can't open history", FALSE);
+    return;
 }
 #endif				/* USE_HISTORY */
 

--- a/history.h
+++ b/history.h
@@ -28,4 +28,12 @@ extern char *lastHist(Hist *hist);
 extern char *nextHist(Hist *hist);
 extern char *prevHist(Hist *hist);
 
+#ifdef USE_HISTORY
+extern int loadHistory(Hist *hist);
+extern void saveHistory(Hist *hist, size_t size);
+extern void ldHist(void);
+#else				/* not USE_HISTORY */
+#define ldHist nulcmd
+#endif				/* not USE_HISTORY */
+
 #endif				/* HISTORY_H */

--- a/history.h
+++ b/history.h
@@ -16,6 +16,7 @@ typedef struct {
     HistList *list;
     HistItem *current;
     Hash_sv *hash;
+    long long mtime;
 } Hist;
 
 extern Hist *newHist(void);

--- a/proto.h
+++ b/proto.h
@@ -391,7 +391,7 @@ extern char *inputLineHistSearch(char *prompt, char *def_str, int flag,
 extern Str unescape_spaces(Str s);
 #ifdef USE_HISTORY
 extern Buffer *historyBuffer(Hist *hist);
-extern void loadHistory(Hist *hist);
+extern int loadHistory(Hist *hist);
 extern void saveHistory(Hist *hist, size_t size);
 extern void ldHist(void);
 #else				/* not USE_HISTORY */

--- a/proto.h
+++ b/proto.h
@@ -391,11 +391,6 @@ extern char *inputLineHistSearch(char *prompt, char *def_str, int flag,
 extern Str unescape_spaces(Str s);
 #ifdef USE_HISTORY
 extern Buffer *historyBuffer(Hist *hist);
-extern int loadHistory(Hist *hist);
-extern void saveHistory(Hist *hist, size_t size);
-extern void ldHist(void);
-#else				/* not USE_HISTORY */
-#define ldHist nulcmd
 #endif				/* not USE_HISTORY */
 extern double log_like(int x);
 extern struct table *newTable(void);


### PR DESCRIPTION
Check if the history file was changed after startup. If it was changed, read it
and merge the current history into it.