### PR TITLE
acinclude.m4: fix configure tests broken with Clang 15 (implicit func…

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -904,7 +904,8 @@ AC_DEFUN([AC_W3M_SIGSETJMP],
 [AC_SUBST(HAVE_SIGSETJMP)
 AC_MSG_CHECKING(for sigsetjmp)
 AC_TRY_COMPILE(
-[#include <setjmp.h>],
+[#include <setjmp.h>
+ #include <stdlib.h>],
 [ jmp_buf env;
    if (sigsetjmp(env, 1) != 0) { exit(0); } siglongjmp(env, 1);],
 [have_sigsetjmp="yes"; AC_DEFINE(HAVE_SIGSETJMP)],


### PR DESCRIPTION
…tion declarations)

Clang 15 makes implicit function declarations fatal by default which leads to some configure tests silently failing/returning the wrong result.

Signed-off-by: Sam James <sam@gentoo.org>