### PR TITLE
Add high-intensity colors option and cli flag.

### DIFF
--- a/doc/MANUAL.html
+++ b/doc/MANUAL.html
@@ -106,6 +106,14 @@ insertions tagged with "mh 2016-03-29" and "mh 2016-06-11" come from the latest 
     </p>
    </dd>
    <dt>
+    -H
+   </dt>
+   <dd>
+    <p>
+    use high-intensity colors
+    </p>
+   </dd>
+   <dt>
     -M
    </dt>
    <dd>

--- a/doc/w3m.1
+++ b/doc/w3m.1
@@ -55,6 +55,9 @@ may take an argument.
 \fB\-B\fP
 with no other target defined, use the bookmark page for startup
 .TP
+\fB\-H\fP
+use high-intensity colors
+.TP
 \fB\-M\fP
 monochrome display
 .TP

--- a/fm.h
+++ b/fm.h
@@ -957,6 +957,7 @@ global int override_user_agent init(FALSE);
 
 #ifdef USE_COLOR
 global int useColor init(TRUE);
+global int highIntensityColors init(FALSE);
 global int basic_color init(8);	/* don't change */
 global int anchor_color init(4);	/* blue  */
 global int image_color init(2);	/* green */

--- a/main.c
+++ b/main.c
@@ -219,6 +219,7 @@ fusage(FILE * f, int err)
     fprintf(f, "    -v               visual startup mode\n");
 #ifdef USE_COLOR
     fprintf(f, "    -M               monochrome display\n");
+    fprintf(f, "    -H               use high-intensity colors\n");
 #endif				/* USE_COLOR */
     fprintf(f,
 	    "    -N               open URL of command line on each new tab\n");
@@ -630,6 +631,8 @@ main(int argc, char **argv)
 #ifdef USE_COLOR
 	    else if (!strcmp("-M", argv[i]))
 		useColor = FALSE;
+	    else if (!strcmp("-H", argv[i]))
+		highIntensityColors = TRUE;
 #endif				/* USE_COLOR */
 	    else if (!strcmp("-B", argv[i]))
 		load_bookmark = TRUE;

--- a/rc.c
+++ b/rc.c
@@ -96,6 +96,7 @@ static int OptionEncode = FALSE;
 #define CMT_FOLD_TEXTAREA N_("Fold lines in TEXTAREA")
 #define CMT_DISP_INS_DEL N_("Display INS, DEL, S and STRIKE element")
 #define CMT_COLOR        N_("Display with color")
+#define CMT_HINTENSITY_COLOR N_("Use high-intensity colors")
 #define CMT_B_COLOR      N_("Color of normal character")
 #define CMT_A_COLOR      N_("Color of anchor")
 #define CMT_I_COLOR      N_("Color of image link")
@@ -467,6 +468,7 @@ struct param_ptr params1[] = {
 #ifdef USE_COLOR
 struct param_ptr params2[] = {
     {"color", P_INT, PI_ONOFF, (void *)&useColor, CMT_COLOR, NULL},
+    {"high-intensity", P_INT, PI_ONOFF, (void *)&highIntensityColors, CMT_HINTENSITY_COLOR, NULL},
     {"basic_color", P_COLOR, PI_SEL_C, (void *)&basic_color, CMT_B_COLOR,
      (void *)colorstr},
     {"anchor_color", P_COLOR, PI_SEL_C, (void *)&anchor_color, CMT_A_COLOR,

--- a/terms.c
+++ b/terms.c
@@ -1679,7 +1679,7 @@ static char *
 color_seq(int colmode)
 {
     static char seqbuf[32];
-    sprintf(seqbuf, "\033[%dm", ((colmode >> 8) & 7) + 30);
+    sprintf(seqbuf, "\033[%dm", ((colmode >> 8) & 7) + (highIntensityColors ? 90 : 30));
     return seqbuf;
 }
 


### PR DESCRIPTION
This adds a flag to switch between [high-intensity and standard colors](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) in foreground, that can be set from the options menu or cli flag, allowing more readability in some terminals ( #250)