### PR TITLE
Don't error out on deprecated declaration warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,6 @@ jobs:
         run: ./configure --enable-alarm --enable-ansi_color --enable-color --enable-cookie --enable-external_uri_loader --enable-gopher --enable-image --enable-ipv6 --enable-m17n --enable-menu --enable-mouse --enable-nls --enable-nntp --enable-sslverify --enable-unicode --enable-w3mmailer --with-imagelib=imlib2 --with-migemo="cmigemo -q -d /usr/share/cmigemo/utf-8/migemo-dict" --with-ssl --with-gc
 
       - name: build
-        run: OPTS='-Wno-unused-result -Werror' make
+        # TODO(rkta): Remove -Wno-error=deprecated-declarations once support for
+        # OpenSSL 3.0 has arrived.
+        run: make OPTS='-Werror -Wno-error=deprecated-declarations -Wno-unused-result'

--- a/file.c
+++ b/file.c
@@ -8199,6 +8199,8 @@ save2tmp(URLFile uf, char *tmpf)
     int check = 0;
     if (uf.scheme == SCM_NEWS) {
 	char c;
+	if (!uf.stream)
+		return -1;
 	while (c = UFgetc(&uf), !iseos(uf.stream)) {
 	    if (c == '\n') {
 		if (check == 0)

--- a/rc.c
+++ b/rc.c
@@ -1245,7 +1245,6 @@ static int
 do_recursive_mkdir(const char *dir)
 {
     char *ch, *dircpy, tmp;
-    size_t n;
     struct stat st;
 
     if (*dir == '\0')

--- a/table.c
+++ b/table.c
@@ -3503,7 +3503,7 @@ correct_table_matrix4(struct table *t, int col, int cspan, char *flags,
 static void
 set_table_matrix0(struct table *t, int maxwidth)
 {
-    int size = t->maxcol + 1;
+    size_t size = t->maxcol + 1;
     int i, j, k, bcol, ecol;
     int width;
     double w0, w1, w, s, b;


### PR DESCRIPTION
---

Main purpose of this PR is to prevent a build failure with the Github Action.
It also fixes some build failures on other systems.

---

The function `unsigned char *MD5(const unsigned char *d, size_t n, unsigned
char *md)` from OpenSSL is deprecated and therefore generates lots of
warnings in the build when compiling against OpenSSL 3.0.

Do not treat these warnings as errors, but keep the warning active. This 
should be reverted once OpenSSL-3.0 support arrives.