### PR TITLE
Handle failed system calls

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -90,11 +90,11 @@ MODEL=@W3M_TARGET@-@W3M_LANG@
 SRCS=main.c file.c buffer.c display.c etc.c search.c linein.c table.c local.c \
 	form.c map.c frame.c rc.c menu.c mailcap.c image.c \
 	symbol.c entity.c terms.c url.c ftp.c mimehead.c regex.c news.c \
-	func.c cookie.c history.c backend.c $(KEYBIND_SRC)
+	func.c cookie.c history.c backend.c util.c $(KEYBIND_SRC)
 OBJS=main.o file.o buffer.o display.o etc.o search.o linein.o table.o local.o\
 	form.o map.o frame.o rc.o menu.o mailcap.o image.o \
 	symbol.o entity.o terms.o url.o ftp.o mimehead.o regex.o news.o \
-	func.o cookie.o history.o backend.o $(KEYBIND_OBJ)
+	func.o cookie.o history.o backend.o util.o $(KEYBIND_OBJ)
 LSRCS=anchor.c parsetagx.c tagtable.c istream.c
 LOBJS=anchor.o parsetagx.o tagtable.o istream.o
 LLOBJS=version.o

--- a/display.c
+++ b/display.c
@@ -1,4 +1,6 @@
 /* $Id: display.c,v 1.71 2010/07/18 14:10:09 htrb Exp $ */
+#include "display.h"
+
 #include <signal.h>
 #include "fm.h"
 

--- a/display.h
+++ b/display.h
@@ -1,0 +1,7 @@
+#ifndef W3M_DISPLAY_H
+#define W3M_DISPLAY_H
+
+void fmInit(void);
+void fmTerm(void);
+
+#endif

--- a/file.c
+++ b/file.c
@@ -1,5 +1,6 @@
 /* $Id: file.c,v 1.266 2012/05/22 09:45:56 inu Exp $ */
 /* vi: set sw=4 ts=8 ai sm noet : */
+#include "display.h"
 #include "fm.h"
 #include <sys/types.h>
 #include "myctype.h"

--- a/form.c
+++ b/form.c
@@ -9,6 +9,7 @@
 #include "myctype.h"
 #include "local.h"
 #include "regex.h"
+#include "util.h"
 
 extern Str *textarea_str;
 extern int max_textarea;
@@ -603,9 +604,8 @@ input_textarea(FormItemList *fi)
 	form_fputs_decode(fi->value, f);
     fclose(f);
 
-    fmTerm();
-    system(myEditor(Editor, tmpf, 1)->ptr);
-    fmInit();
+    if (exec_cmd(myEditor(Editor, tmpf, 1)->ptr))
+	    goto input_end;
 
     if (fi->readonly)
 	goto input_end;

--- a/form.c
+++ b/form.c
@@ -2,6 +2,7 @@
 /* 
  * HTML forms
  */
+#include "display.h"
 #include "fm.h"
 #include "parsetag.h"
 #include "parsetagx.h"

--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@
 #if defined(__CYGWIN__) && defined(USE_BINMODE_STREAM)
 #include <io.h>
 #endif
+#include "display.h"
 #include "terms.h"
 #include "myctype.h"
 #include "regex.h"

--- a/main.c
+++ b/main.c
@@ -37,6 +37,8 @@ extern int do_getch();
 #endif				/* defined(USE_GPM) || defined(USE_SYSMOUSE) */
 #endif
 
+#include "util.h"
+
 #ifdef __MINGW32_VERSION
 #include <winsock.h>
 
@@ -2242,7 +2244,7 @@ DEFUN(execsh, EXEC_SHELL SHELL, "Execute shell command and display output")
     if (cmd != NULL && *cmd != '\0') {
 	fmTerm();
 	printf("\n");
-	system(cmd);
+	(void)!system(cmd); /* We do not care about the exit code here! */
 	/* FIXME: gettextize? */
 	printf("\n[Hit any key]");
 	fflush(stdout);
@@ -2792,9 +2794,7 @@ DEFUN(editBf, EDIT, "Edit local source")
     else
 	cmd = myEditor(Editor, shell_quote(fn),
 		       cur_real_linenumber(Currentbuf));
-    fmTerm();
-    system(cmd->ptr);
-    fmInit();
+    exec_cmd(cmd->ptr);
 
     displayBuffer(Currentbuf, B_FORCE_REDRAW);
     reload();
@@ -2815,10 +2815,8 @@ DEFUN(editScr, EDIT_SCREEN, "Edit rendered copy of document")
     }
     saveBuffer(Currentbuf, f, TRUE);
     fclose(f);
-    fmTerm();
-    system(myEditor(Editor, shell_quote(tmpf),
-		    cur_real_linenumber(Currentbuf))->ptr);
-    fmInit();
+    exec_cmd(myEditor(Editor, shell_quote(tmpf),
+		   cur_real_linenumber(Currentbuf))->ptr);
     unlink(tmpf);
     displayBuffer(Currentbuf, B_FORCE_REDRAW);
 }
@@ -3111,10 +3109,8 @@ handleMailto(char *url)
 	if ((pos = strchr(to->ptr, '?')) != NULL)
 	    Strtruncate(to, pos - to->ptr);
     }
-    fmTerm();
-    system(myExtCommand(Mailer, shell_quote(file_unquote(to->ptr)),
+    exec_cmd(myExtCommand(Mailer, shell_quote(file_unquote(to->ptr)),
 			FALSE)->ptr);
-    fmInit();
     displayBuffer(Currentbuf, B_FORCE_REDRAW);
     pushHashHist(URLHist, url);
     return 1;

--- a/proto.h
+++ b/proto.h
@@ -320,8 +320,6 @@ extern void copyBuffer(Buffer *a, Buffer *b);
 extern Buffer *prevBuffer(Buffer *first, Buffer *buf);
 extern int writeBufferCache(Buffer *buf);
 extern int readBufferCache(Buffer *buf);
-extern void fmTerm(void);
-extern void fmInit(void);
 extern void displayBuffer(Buffer *buf, int mode);
 extern void addChar(char c, Lineprop mode);
 #ifdef USE_M17N
@@ -529,7 +527,6 @@ extern void term_cbreak(void);
 extern void term_title(char *s);
 extern void flush_tty(void);
 extern void toggle_stand(void);
-extern char getch(void);
 extern void bell(void);
 extern int sleep_till_anykey(int sec, int purge);
 #ifdef USE_IMAGE

--- a/terms.h
+++ b/terms.h
@@ -38,4 +38,6 @@ extern void put_image_kitty(char *url, int x, int y, int w, int h, int sx, int s
 extern int get_pixel_per_cell(int *ppc, int *ppl);
 #endif
 
+char getch(void);
+
 #endif				/* not TERMS_H */

--- a/util.c
+++ b/util.c
@@ -1,0 +1,26 @@
+#include "util.h"
+
+#include "display.h"
+#include "terms.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+exec_cmd(char *cmd)
+{
+    int rv;
+
+    fmTerm();
+    if ((rv = system(cmd))) {
+	printf("\n[Hit any key]");
+	fflush(stdout);
+	fmInit();
+	getch();
+
+	return rv;
+    }
+    fmInit();
+
+    return 0;
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,6 @@
+#ifndef W3M_UTIL_H
+#define W3M_UTIL_H
+
+int exec_cmd(char *cmd);
+
+#endif


### PR DESCRIPTION
---

This PR includes/depends on PR #255

---

Introduce a separate TU for utility functions util.c. Add a function 
exec_cmd to simplify execution of system commands with error handling.

While at it, suppress a warning about unused result when executing a shell
command. As we only display the command's output we do not care about the
exit code.

This fixes Debian bug #398989[0]

[0]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=398989