### PR TITLE
Fix possible buffer overflow in addMultirowsImg

### DIFF
--- a/anchor.c
+++ b/anchor.c
@@ -614,6 +614,13 @@ addMultirowsImg(Buffer *buf, AnchorList *al)
 	    a->slave = TRUE;
 	    a->image = img;
 	    a->end.pos = pos + ecol - col;
+	    /* TODO:
+	     * This is a hack to avoid adding images positioned on the wrong
+	     * line outside line bounds (which would cause a buffer overrun).
+	     * The actual bug is most likely in the image placement code.
+	     */
+	    if (pos < 0 || a->end.pos > l->size)
+		continue;
 	    for (k = pos; k < a->end.pos; k++)
 		l->propBuf[k] |= PE_IMAGE;
 	    if (a_href.url) {


### PR DESCRIPTION
In 4e464819, a workaround was applied to prevent buffer overruns in addMultirowsForm. Unfortunately, the same issue affects addMultirowsImg; I have been able to consistently reproduce it by enabling inline images and visiting https://html.spec.whatwg.org.

I have not yet figured out why exactly this can happen, but the start/end indices are calculated in the same way at both locations (i.e. at addMultirowsForm too), so it is unsurprising that the issue persists. For now, I've just copy-pasted the same bounds checks; further investigation might be needed on whether the COLPOS/columnPos functions themselves are faulty or they were just used incorrectly.