### PR TITLE
Directly piping files into external commands (v2)

### DIFF
--- a/doc/README.mailcap
+++ b/doc/README.mailcap
@@ -1,0 +1,46 @@
+On mailcap support
+
+                                                     (11/07/2000) Okabe Katsuya
+                                                        okabek@guitar.ocn.ne.jp
+                                                     (translated from Japanese)
+
+ * Starting with the 10/6/2000 version, w3m follows the mailcap fields
+   `nametemplate', `needsterminal', `copiousoutput', `edit' (see RFC-1524).
+   Also, starting with the 10/26/2000 version, the path of mailcap and
+   mime.types may be set from the option settings panel.
+
+ * In mailcap, the %s is replaced with the path name passed to the external
+   command, and %t is replaced with the file's content type.
+
+ * When a mailcap entry contains a test=command field, the file will only be
+   opened if the test command returns true. e.g. if you write
+
+   image/gif; xv '%s'; test=test "$DISPLAY"
+
+   then xv will only be launched if the DISPLAY environment variable is set.
+
+ * When a mailcap entry contains the `copiousoutput' field, the external
+   command's output is read into a new buffer.
+   e.g.
+
+   application/x-troff-man;/usr/bin/nroff -mandoc;copiousoutput
+
+   For the most part, this functionality can substitute all uses of LESSOPEN.
+   Therefore, usage of LESSOPEN has been made optional.
+
+   w3m has an extension called `x-htmloutput'. Just like `copiousoutput',
+   this reads the command's output into the buffer. The difference is that
+   `x-htmloutput' renders the output as HTML. For interoperability with other
+   browsers, it may be best to place entries not containing x-htmloutput before
+   entries that do contain the flag.
+
+ * nametemplate= specifies the extension of files passed to the external
+   command.
+   Normally, when a temporary file is created, the file extension present
+   in the URL is used. This can be changed using the nametemplate= field.
+   e.g.
+
+   application/x-dvi;xdvi '%s';test=test -n "$DISPLAY";nametemplate=%s.dvi
+
+ * For the meaning of the `needsterminal' and `edit' fields, please consult
+   RFC 1524.

--- a/proto.h
+++ b/proto.h
@@ -283,7 +283,8 @@ extern Buffer *openPagerBuffer(InputStream stream, Buffer *buf);
 extern Buffer *openGeneralPagerBuffer(InputStream stream);
 extern Line *getNextPage(Buffer *buf, int plen);
 extern int save2tmp(URLFile uf, char *tmpf);
-extern Buffer *doExternal(URLFile uf, char *type, Buffer *defaultbuf);
+extern Buffer *doExternal(URLFile uf, char *type, Buffer *defaultbuf,
+			  int *needs_halfclose);
 extern int _doFileCopy(char *tmpf, char *defstr, int download);
 #define doFileCopy(tmpf, defstr) _doFileCopy(tmpf, defstr, FALSE);
 extern int doFileMove(char *tmpf, char *defstr);


### PR DESCRIPTION
Includes the following:

* Stream input into mailcap entries without saving first where possible.
* README.mailcap english translation.


This is a simpler patch than my previous attempt[^1]. `PIPE_LINK` and
`x-nosaveinput` have been dropped. Instead, streaming is enabled for the
cases where:

* No `%s` template exists in the mailcap entry, and
* output of external viewers is ignored (or is displayed through needsterminal).

Another improvement over the previous patch: UFhalfclose is used instead
of UFclose, so that the parent process does not wait for background external
viewer processes to finish downloading.

Stuff not implemented:

* I originally wanted to add streaming for copiousoutput/x-htmloutput; while
  this would be the "right thing" to do, it seems difficult to implement +
  pointless since w3m does not support incremental rendering anyway. So I
  decided to stick with the "download first" approach for these cases.
* I wanted to add an environment variable that is set to the target URL
  before the entry is executed, but in the end I decided to keep the scope
  of this PR narrower and did not add it. Maybe in a future PR.

[^1]: https://github.com/tats/w3m/pull/275
