### PR TITLE
w3mman2html.cgi: convert https to href links

### DIFF
--- a/scripts/w3mman/w3mman2html.cgi.in
+++ b/scripts/w3mman/w3mman2html.cgi.in
@@ -162,7 +162,7 @@ EOF
     next;
   }
 
-  s@(http|ftp)://[\w.\-/~]+[\w/]@<a href="$&">$&</a>@g;
+  s@(https|http|ftp)://[\w.\-/~]+[\w/]@<a href="$&">$&</a>@g;
   s@\b(mailto:|)(\w[\w.\-]*\@\w[\w.\-]*\.[\w.\-]*\w)@<a href="mailto:$2">$1$2</a>@g;
   s@(\W)(\~?/[\w.][\w.\-/~]*)@$1 . &file_ref($2)@ge;
   s@(include(<\/?[bu]\>|\s)*\&lt;)([\w.\-/]+)@$1 . &include_ref($3)@ge;


### PR DESCRIPTION
In addition to http|ftp do also convert https links to proper links with a href statement.

Fixes: #292