### PR TITLE
Auto inline images

### DIFF
--- a/display.c
+++ b/display.c
@@ -530,12 +530,14 @@ drawAnchorCursor0(Buffer *buf, AnchorList *al, int hseq, int prevhseq,
 	    int start_pos = an->start.pos;
 	    int end_pos = an->end.pos;
 	    for (i = an->start.pos; i < an->end.pos; i++) {
-	        if (enable_inline_image && (l->propBuf[i] & PE_IMAGE)) {
+#ifdef USE_IMAGE
+		if (enable_inline_image && (l->propBuf[i] & PE_IMAGE)) {
 		    if (start_pos == i)
 			start_pos = i + 1;
 		    else if (end_pos == an->end.pos)
 		        end_pos = i - 1;
 		}
+#endif
 		if (l->propBuf[i] & (PE_IMAGE | PE_ANCHOR | PE_FORM)) {
 		    if (active)
 			l->propBuf[i] |= PE_ACTIVE;

--- a/fm.h
+++ b/fm.h
@@ -317,11 +317,14 @@ extern int REV_LB[];
 #define EOL(l) (&(l)->ptr[(l)->length])
 #define IS_EOL(p,l) ((p)==&(l)->ptr[(l)->length])
 
+#ifdef USE_IMAGE
+#define INLINE_IMG_AUTO		-1
 #define INLINE_IMG_NONE		0
 #define INLINE_IMG_OSC5379	1
 #define INLINE_IMG_SIXEL	2
 #define INLINE_IMG_ITERM2	3
 #define INLINE_IMG_KITTY	4
+#endif
 
 /* 
  * Types.
@@ -940,7 +943,10 @@ global char *CurrentKeyData;
 global char *CurrentCmdData;
 global char *w3m_reqlog;
 extern char *w3m_version;
-extern int enable_inline_image;
+#ifdef USE_IMAGE
+global unsigned char enable_inline_image init(INLINE_IMG_NONE);
+global signed char enable_inline_image_config init(INLINE_IMG_AUTO);
+#endif
 
 #define DUMP_BUFFER   0x01
 #define DUMP_HEAD     0x02

--- a/main.c
+++ b/main.c
@@ -127,8 +127,6 @@ static int searchKeyNum(void);
 #define help() fusage(stdout, 0)
 #define usage() fusage(stderr, 1)
 
-int enable_inline_image;
-
 static void
 fversion(FILE * f)
 {
@@ -719,13 +717,13 @@ main(int argc, char **argv)
 		    set_pixel_per_line = TRUE;
 		}
 	    }
-#endif
 	    else if (!strcmp("-ri", argv[i])) {
 	        enable_inline_image = INLINE_IMG_OSC5379;
 	    }
 	    else if (!strcmp("-sixel", argv[i])) {
 		enable_inline_image = INLINE_IMG_SIXEL;
 	    }
+#endif
 	    else if (!strcmp("-num", argv[i]))
 		showLineNum = TRUE;
 	    else if (!strcmp("-no-proxy", argv[i]))
@@ -6006,11 +6004,13 @@ deleteFiles()
     }
     while ((f = popText(fileToDelete)) != NULL) {
 	unlink(f);
+#ifdef USE_IMAGE
 	if (enable_inline_image == INLINE_IMG_SIXEL && strcmp(f+strlen(f)-4, ".gif") == 0) {
 	    Str firstframe = Strnew_charp(f);
 	    Strcat_charp(firstframe, "-1");
 	    unlink(firstframe->ptr);
         }
+#endif
     }
 }
 

--- a/rc.c
+++ b/rc.c
@@ -377,6 +377,7 @@ static struct sel_c graphic_char_str[] = {
 
 #ifdef USE_IMAGE
 static struct sel_c inlineimgstr[] = {
+    {N_S(INLINE_IMG_AUTO), N_("auto-select protocol")},
     {N_S(INLINE_IMG_NONE), N_("external command")},
     {N_S(INLINE_IMG_OSC5379), N_("OSC 5379 (mlterm)")},
     {N_S(INLINE_IMG_SIXEL), N_("sixel (img2sixel)")},
@@ -449,7 +450,7 @@ struct param_ptr params1[] = {
      CMT_EXT_IMAGE_VIEWER, NULL},
     {"image_scale", P_SCALE, PI_TEXT, (void *)&image_scale, CMT_IMAGE_SCALE,
      NULL},
-    {"inline_img_protocol", P_INT, PI_SEL_C, (void *)&enable_inline_image,
+    {"inline_img_protocol", P_CHARINT, PI_SEL_C, (void *)&enable_inline_image_config,
      CMT_INLINE_IMG_PROTOCOL, (void *)inlineimgstr},
     {"imgdisplay", P_STRING, PI_TEXT, (void *)&Imgdisplay, CMT_IMGDISPLAY,
      NULL},
@@ -1313,7 +1314,7 @@ sync_with_option(void)
     init_migemo();
 #endif
 #ifdef USE_IMAGE
-    if (fmInitialized && (displayImage || enable_inline_image))
+    if (fmInitialized && (displayImage || enable_inline_image_config))
 	initImage();
 #else
     displayImage = FALSE;	/* XXX */

--- a/terms.h
+++ b/terms.h
@@ -35,6 +35,7 @@ extern void put_image_osc5379(char *url, int x, int y, int w, int h, int sx, int
 extern void put_image_sixel(char *url, int x, int y, int w, int h, int sx, int sy, int sw, int sh, int n_terminal_image);
 extern void put_image_iterm2(char *url, int x, int y, int w, int h);
 extern void put_image_kitty(char *url, int x, int y, int w, int h, int sx, int sy, int sw, int sh, int c, int r);
+extern int img_protocol_test_for_sixel(void);
 extern int get_pixel_per_cell(int *ppc, int *ppl);
 #endif
 


### PR DESCRIPTION
Deduce an appropriate value for inline_img_protocol rather than requiring it to be set manually with eg. `-o auto_inline_img=4` for kitty.

Tangentially, should `struct _termialImage {...} TerminalImage` at image.c:11,27 be `_terminalImage`? Not important currently since nothing uses the struct tag as opposed to the `TerminalImage` typedef, but could surprise someone eventually